### PR TITLE
V2.6

### DIFF
--- a/BTD6AutoCommunity/BTD6AutoCommunity.csproj
+++ b/BTD6AutoCommunity/BTD6AutoCommunity.csproj
@@ -105,6 +105,7 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
@@ -119,7 +120,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Core\ScreenshotCapturer.cs" />
     <Compile Include="GameObjects\GameEnums.cs" />
+    <Compile Include="GameObjects\MapInfo.cs" />
     <Compile Include="Models\DifficultyDisplayItem.cs" />
     <Compile Include="Models\FunctionDisplayItem.cs" />
     <Compile Include="Models\HeroDisplayItem.cs" />

--- a/BTD6AutoCommunity/BTD6AutoCommunity.csproj
+++ b/BTD6AutoCommunity/BTD6AutoCommunity.csproj
@@ -62,7 +62,7 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Assets\Icons\favicon.ico</ApplicationIcon>
@@ -162,7 +162,6 @@
     <Compile Include="Services\MouseCoordinateDisplayService.cs" />
     <Compile Include="Services\StrategyManager.cs" />
     <Compile Include="Strategies\Base\BaseStrategy.cs" />
-    <Compile Include="Strategies\BlackBorderStrategy.cs" />
     <Compile Include="Strategies\CirculationStrategy.cs" />
     <Compile Include="Strategies\CollectionStrategy.cs" />
     <Compile Include="Core\Constants.cs" />
@@ -172,6 +171,7 @@
     <Compile Include="Core\InputSimulator.cs" />
     <Compile Include="Core\LevelDataMonitor.cs" />
     <Compile Include="Core\LogHandler.cs" />
+    <Compile Include="Strategies\BlackBorderStrategy.cs" />
     <Compile Include="Strategies\RaceStrategy.cs" />
     <Compile Include="Strategies\InGame\InGameActionExecutor.cs" />
     <Compile Include="Core\WindowApiWrapper.cs" />

--- a/BTD6AutoCommunity/Core/Constants.cs
+++ b/BTD6AutoCommunity/Core/Constants.cs
@@ -431,6 +431,7 @@ namespace BTD6AutoCommunity.Core
             { Maps.DarkCastle, "黑暗城堡" },
             { Maps.MuddyPuddles, "泥泞的水坑" },
             { Maps.Ouch, "#哎哟" },
+            { Maps.TrickyTracks, "棘手的轨道" },
             { Maps.Unknown, "未知地图" }
         };
 
@@ -523,6 +524,7 @@ namespace BTD6AutoCommunity.Core
             Maps.OffTheCoast,
             Maps.Cornfield,
             Maps.Underground,
+            Maps.TrickyTracks,
             Maps.GlacialTrail,
             Maps.DarkDungeon,
             Maps.Sanctuary,
@@ -610,6 +612,7 @@ namespace BTD6AutoCommunity.Core
             { Maps.LastResort, MapTypes.Advanced },
             { Maps.EnchantedGlade, MapTypes.Advanced },
             { Maps.SunsetGulch, MapTypes.Advanced },
+            { Maps.TrickyTracks, MapTypes.Expert },
             { Maps.GlacialTrail, MapTypes.Expert },
             { Maps.DarkDungeon, MapTypes.Expert },
             { Maps.Sanctuary, MapTypes.Expert },

--- a/BTD6AutoCommunity/Core/Constants.cs
+++ b/BTD6AutoCommunity/Core/Constants.cs
@@ -5,14 +5,11 @@ using System.Linq;
 using BTD6AutoCommunity.Strategies;
 using BTD6AutoCommunity.ScriptEngine;
 using BTD6AutoCommunity.GameObjects;
-using System.Collections.ObjectModel;
-using System.Windows.Forms;
 
 namespace BTD6AutoCommunity.Core
 {
     public static class Constants
     {
-
         //public static Dictionary<int, string> InstructionPackages => new Dictionary<int, string>
         //{
         //    { 0, "022飞镖猴(模范)" },
@@ -53,20 +50,20 @@ namespace BTD6AutoCommunity.Core
         //    { 53, "032刺钉工厂(靠近)" }
         //};
 
-        public static Dictionary<LevelMode, LevelDifficulties> LevelModeToDifficulty => new Dictionary<LevelMode, LevelDifficulties>()
+        public static Dictionary<LevelModes, LevelDifficulties> LevelModeToDifficulty => new Dictionary<LevelModes, LevelDifficulties>()
         {
-            { LevelMode.Standard, LevelDifficulties.Any },
-            { LevelMode.PrimaryOnly, LevelDifficulties.Easy },
-            { LevelMode.Deflation, LevelDifficulties.Easy },
-            { LevelMode.MilitaryOnly, LevelDifficulties.Medium },
-            { LevelMode.Apopalypse, LevelDifficulties.Medium },
-            { LevelMode.Reverse, LevelDifficulties.Medium },
-            { LevelMode.MagicMonkeysOnly, LevelDifficulties.Hard },
-            { LevelMode.DoubleHpMoabs, LevelDifficulties.Hard },
-            { LevelMode.HalfCash, LevelDifficulties.Hard },
-            { LevelMode.AlternateBloonsRounds, LevelDifficulties.Hard },
-            { LevelMode.Impoppable, LevelDifficulties.Hard },
-            { LevelMode.CHIMPS, LevelDifficulties.Hard }
+            { LevelModes.Standard, LevelDifficulties.Any },
+            { LevelModes.PrimaryOnly, LevelDifficulties.Easy },
+            { LevelModes.Deflation, LevelDifficulties.Easy },
+            { LevelModes.MilitaryOnly, LevelDifficulties.Medium },
+            { LevelModes.Apopalypse, LevelDifficulties.Medium },
+            { LevelModes.Reverse, LevelDifficulties.Medium },
+            { LevelModes.MagicMonkeysOnly, LevelDifficulties.Hard },
+            { LevelModes.DoubleHpMoabs, LevelDifficulties.Hard },
+            { LevelModes.HalfCash, LevelDifficulties.Hard },
+            { LevelModes.AlternateBloonsRounds, LevelDifficulties.Hard },
+            { LevelModes.Impoppable, LevelDifficulties.Hard },
+            { LevelModes.CHIMPS, LevelDifficulties.Hard }
         };
 
         public static Dictionary<CollectionMode, string> CollectionScripts => new Dictionary<CollectionMode, string>()
@@ -77,23 +74,23 @@ namespace BTD6AutoCommunity.Core
         };
 
 
-        private static readonly Dictionary<LevelMode, Point> LevelModePoint = new Dictionary<LevelMode, Point>()
+        private static readonly Dictionary<LevelModes, Point> LevelModePoint = new Dictionary<LevelModes, Point>()
         {
-            { LevelMode.Standard, new Point(630, 590) },
-            { LevelMode.PrimaryOnly, new Point(960, 450) },
-            { LevelMode.Deflation, new Point(1300, 450) },
-            { LevelMode.MilitaryOnly, new Point(960, 450) },
-            { LevelMode.Apopalypse, new Point(1300, 450) },
-            { LevelMode.Reverse, new Point(960, 750) },
-            { LevelMode.MagicMonkeysOnly, new Point(960, 450) },
-            { LevelMode.DoubleHpMoabs, new Point(1300, 450) },
-            { LevelMode.HalfCash, new Point(1600, 450) },
-            { LevelMode.AlternateBloonsRounds, new Point(960, 750) },
-            { LevelMode.Impoppable, new Point(1300, 750) },
-            { LevelMode.CHIMPS, new Point(1600, 750) }
+            { LevelModes.Standard, new Point(630, 590) },
+            { LevelModes.PrimaryOnly, new Point(960, 450) },
+            { LevelModes.Deflation, new Point(1300, 450) },
+            { LevelModes.MilitaryOnly, new Point(960, 450) },
+            { LevelModes.Apopalypse, new Point(1300, 450) },
+            { LevelModes.Reverse, new Point(960, 750) },
+            { LevelModes.MagicMonkeysOnly, new Point(960, 450) },
+            { LevelModes.DoubleHpMoabs, new Point(1300, 450) },
+            { LevelModes.HalfCash, new Point(1600, 450) },
+            { LevelModes.AlternateBloonsRounds, new Point(960, 750) },
+            { LevelModes.Impoppable, new Point(1300, 750) },
+            { LevelModes.CHIMPS, new Point(1600, 750) }
         };
 
-        public static Point GetLevelModePos(LevelMode levelMode)
+        public static Point GetLevelModePos(LevelModes levelMode)
         {
             return LevelModePoint.TryGetValue(levelMode, out var pos)
                 ? pos
@@ -213,15 +210,15 @@ namespace BTD6AutoCommunity.Core
         }
 
         public static List<FunctionTypes> FunctionsList => new List<FunctionTypes>
-        { FunctionTypes.Custom, FunctionTypes.Collection, FunctionTypes.Circulation, FunctionTypes.Race};
+        { FunctionTypes.Custom, FunctionTypes.Collection, FunctionTypes.Circulation, FunctionTypes.Race, FunctionTypes.BlackBorder};
 
         private static readonly Dictionary<Heroes, string> _heroNames = new Dictionary<Heroes, string>
         {
             { Heroes.Quincy, "昆西" },
-            { Heroes.Gwendolin, "格温多林" },
+            { Heroes.Gwendolin, "格温多琳" },
             { Heroes.StrikerJones, "先锋琼斯"},
             { Heroes.ObynGreenfoot, "奥本"},
-            { Heroes.Rosalia, "罗莎莉亚" },
+            { Heroes.Rosalia, "罗莎莉娅" },
             { Heroes.CaptainChurchill, "上尉丘吉尔"},
             { Heroes.Benjamin, "本杰明"},
             { Heroes.PatFusty, "帕特"},
@@ -233,6 +230,7 @@ namespace BTD6AutoCommunity.Core
             { Heroes.Psi, "灵机"},
             { Heroes.Geraldo, "杰拉尔多"},
             { Heroes.Corvus, "科沃斯"},
+            { Heroes.Silas, "西拉斯" },
             { Heroes.Unkown, "未知英雄" }
         };
 
@@ -255,16 +253,18 @@ namespace BTD6AutoCommunity.Core
         public static List<Heroes> HeroesList => new List<Heroes>
         {
             Heroes.Quincy,
+            Heroes.Gwendolin,
             Heroes.StrikerJones,
             Heroes.ObynGreenfoot,
-            Heroes.Rosalia,
-            Heroes.CaptainChurchill,
+            Heroes.Silas,
             Heroes.Benjamin,
             Heroes.PatFusty,
+            Heroes.CaptainChurchill,
             Heroes.Ezili,
-            Heroes.Adora,
+            Heroes.Rosalia,
             Heroes.Etienne,
             Heroes.Sauda,
+            Heroes.Adora,
             Heroes.AdmiralBrickell,
             Heroes.Psi,
             Heroes.Geraldo,
@@ -351,6 +351,7 @@ namespace BTD6AutoCommunity.Core
         {
             { Maps.MonkeyMeadow, "猴子草甸" },
             { Maps.InTheLoop, "循环" },
+            { Maps.ThreeMilesRound, "三矿回合" },
             { Maps.MiddleOfTheRoad, "道路中间" },
             { Maps.TinkerTon, "汀克顿" },
             { Maps.SpaPits, "水疗温泉" },
@@ -396,6 +397,7 @@ namespace BTD6AutoCommunity.Core
             { Maps.Rake, "耙" },
             { Maps.SpiceIslands, "香料群岛" },
             { Maps.LuminousCove, "夜光海湾" },
+            { Maps.LostCrevasse, "失落冰隙" },
             { Maps.CastleRevenge, "城堡复仇" },
             { Maps.DarkPath, "黑暗之径" },
             { Maps.Erosion, "侵蚀" },
@@ -429,7 +431,7 @@ namespace BTD6AutoCommunity.Core
             { Maps.DarkCastle, "黑暗城堡" },
             { Maps.MuddyPuddles, "泥泞的水坑" },
             { Maps.Ouch, "#哎哟" },
-            { Maps.Unkown, "未知地图" }
+            { Maps.Unknown, "未知地图" }
         };
 
         // 获取中文名称
@@ -453,11 +455,12 @@ namespace BTD6AutoCommunity.Core
         {
             Maps.MonkeyMeadow,
             Maps.InTheLoop,
-            Maps.MiddleOfTheRoad,
+            Maps.ThreeMilesRound,
             Maps.SpaPits,
             Maps.TinkerTon,
             Maps.TreeStump,
             Maps.TownCenter,
+            Maps.MiddleOfTheRoad,
             Maps.OneTwoTree,
             Maps.ScrapYard,
             Maps.TheCabin,
@@ -475,6 +478,7 @@ namespace BTD6AutoCommunity.Core
             Maps.Hedge,
             Maps.EndOfTheRoad,
             Maps.Logs,
+            Maps.LostCrevasse,
             Maps.LuminousCove,
             Maps.SulfurSprings,
             Maps.WaterPark,
@@ -538,6 +542,7 @@ namespace BTD6AutoCommunity.Core
         {
             { Maps.MonkeyMeadow, MapTypes.Beginner },
             { Maps.InTheLoop, MapTypes.Beginner },
+            { Maps.ThreeMilesRound, MapTypes.Beginner },
             { Maps.MiddleOfTheRoad, MapTypes.Beginner },
             { Maps.TinkerTon, MapTypes.Beginner },
             { Maps.SpaPits, MapTypes.Beginner },
@@ -583,6 +588,7 @@ namespace BTD6AutoCommunity.Core
             { Maps.Rake, MapTypes.Intermediate },
             { Maps.SpiceIslands, MapTypes.Intermediate },
             { Maps.LuminousCove, MapTypes.Intermediate },
+            { Maps.LostCrevasse, MapTypes.Intermediate },
             { Maps.CastleRevenge, MapTypes.Advanced },
             { Maps.DarkPath, MapTypes.Advanced },
             { Maps.Erosion, MapTypes.Advanced },
@@ -626,24 +632,24 @@ namespace BTD6AutoCommunity.Core
         }
 
 
-        private static readonly Dictionary<LevelMode, string> _levelModeNames = new Dictionary<LevelMode, string>
+        private static readonly Dictionary<LevelModes, string> _levelModeNames = new Dictionary<LevelModes, string>
         {
-            { LevelMode.Standard, "标准" },
-            { LevelMode.PrimaryOnly, "仅初级" },
-            { LevelMode.Deflation, "放气" },
-            { LevelMode.MilitaryOnly, "仅军事" },
-            { LevelMode.Apopalypse, "天启" },
-            { LevelMode.Reverse, "相反" },
-            { LevelMode.MagicMonkeysOnly, "仅魔法" },
-            { LevelMode.DoubleHpMoabs, "双倍生命值MOAB" },
-            { LevelMode.HalfCash, "现金减半" },
-            { LevelMode.AlternateBloonsRounds, "代替气球回合" },
-            { LevelMode.Impoppable, "极难模式" },
-            { LevelMode.CHIMPS, "点击" }
+            { LevelModes.Standard, "标准" },
+            { LevelModes.PrimaryOnly, "仅初级" },
+            { LevelModes.Deflation, "放气" },
+            { LevelModes.MilitaryOnly, "仅军事" },
+            { LevelModes.Apopalypse, "天启" },
+            { LevelModes.Reverse, "相反" },
+            { LevelModes.MagicMonkeysOnly, "仅魔法" },
+            { LevelModes.DoubleHpMoabs, "双倍生命" },
+            { LevelModes.HalfCash, "现金减半" },
+            { LevelModes.AlternateBloonsRounds, "替代气球" },
+            { LevelModes.Impoppable, "极难" },
+            { LevelModes.CHIMPS, "点击" }
         };
 
         // 获取中文名称
-        public static string GetTypeName(LevelMode mode)
+        public static string GetTypeName(LevelModes mode)
         {
             return _levelModeNames.TryGetValue(mode, out var name)
                 ? name
@@ -651,27 +657,27 @@ namespace BTD6AutoCommunity.Core
         }
 
         // 通过数字获取枚举值
-        public static LevelMode GetLevelModeType(int id)
+        public static LevelModes GetLevelModeType(int id)
         {
-            return Enum.GetValues(typeof(LevelMode))
-                .Cast<LevelMode>()
+            return Enum.GetValues(typeof(LevelModes))
+                .Cast<LevelModes>()
                 .FirstOrDefault(e => (int)e == id);
         }
 
-        public static List<LevelMode> ModesList => new List<LevelMode>
+        public static List<LevelModes> ModesList => new List<LevelModes>
         {
-            LevelMode.Standard,
-            LevelMode.PrimaryOnly,
-            LevelMode.Deflation,
-            LevelMode.MilitaryOnly,
-            LevelMode.Apopalypse,
-            LevelMode.Reverse,
-            LevelMode.MagicMonkeysOnly,
-            LevelMode.DoubleHpMoabs,
-            LevelMode.HalfCash,
-            LevelMode.AlternateBloonsRounds,
-            LevelMode.Impoppable,
-            LevelMode.CHIMPS
+            LevelModes.Standard,
+            LevelModes.PrimaryOnly,
+            LevelModes.Deflation,
+            LevelModes.MilitaryOnly,
+            LevelModes.Apopalypse,
+            LevelModes.Reverse,
+            LevelModes.MagicMonkeysOnly,
+            LevelModes.DoubleHpMoabs,
+            LevelModes.HalfCash,
+            LevelModes.AlternateBloonsRounds,
+            LevelModes.Impoppable,
+            LevelModes.CHIMPS
         };
 
 
@@ -1039,9 +1045,9 @@ namespace BTD6AutoCommunity.Core
             {
                 return GetTypeName((Maps)obj);
             }
-            else if (type == typeof(LevelMode))
+            else if (type == typeof(LevelModes))
             {
-                return GetTypeName((LevelMode)obj);
+                return GetTypeName((LevelModes)obj);
             }
             else if (type == typeof(ActionTypes))
             {

--- a/BTD6AutoCommunity/Core/GameContext.cs
+++ b/BTD6AutoCommunity/Core/GameContext.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Drawing;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
 using static BTD6AutoCommunity.Core.WindowApiWrapper;
 
 namespace BTD6AutoCommunity.Core
@@ -131,6 +132,8 @@ namespace BTD6AutoCommunity.Core
                 point.Y * 65535 / screenHeight
             );
         }
+
+
         public override string ToString()
         {
             return $"游戏窗口上下文[Valid={IsValid} | Handle={WindowHandle} " +

--- a/BTD6AutoCommunity/Core/GameStateMachine.cs
+++ b/BTD6AutoCommunity/Core/GameStateMachine.cs
@@ -8,6 +8,10 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Buffers.Text;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Diagnostics;
 
 namespace BTD6AutoCommunity.Core
 {
@@ -103,112 +107,252 @@ namespace BTD6AutoCommunity.Core
     {
         private GameState currentState;
         private readonly GameContext _context;
+        private readonly List<StateRule> _rules;
+        private readonly string _rulesPath = Path.Combine("config", "State_rules.json");
+
         public GameContext Context => _context;
 
         public GameStateMachine(GameContext context)
         {
             _context = context;
             currentState = GameState.UnKnown;
-            // 其他初始化操作...
+            _rules = LoadRules(_rulesPath) ?? new List<StateRule>();
         }
 
-        public GameState GetCurrentState()
+        /// <summary>
+        /// 优先使用 data/state_rules.json 中的规则判断（规则之间是先后优先）。
+        /// OR 行为由添加多条同名 state 规则实现。
+        /// 规则中的单项支持：
+        ///   - "color": 十六进制字符串 "RRGGBB" 或 "#RRGGBB" 或 "0xRRGGBB"
+        ///   - "tolerance": 可选，整数（RGB 差的允许累计值），默认 50
+        ///   - "not": 可选，布尔，若为 true 则表示“非”条件（即颜色不匹配）
+        /// </summary>
+        public GameState GetCurrentState(Bitmap bmp)
         {
             if (!_context.IsValid) return GameState.UnKnown;
 
-            if ((CheckColor(_context, 780, 380, 0xF34A12) && CheckColor(_context, 780, 760, 0x5388D2) && CheckColor(_context, 900, 760, 0x62E200)) ||
-                (CheckColor(_context, 820, 330, 0xF24710) && CheckColor(_context, 820, 760, 0xD2D2D2) && CheckColor(_context, 960, 760, 0xFFFFFF)))
+            if (_rules != null && _rules.Count > 0)
+            {
+                foreach (var rule in _rules)
+                {
+                    //Debug.WriteLine($"Evaluating rule for state: {rule.State}");
+                    if (EvaluateRule(rule, bmp))
+                    {
+                        if (Enum.TryParse(rule.State, true, out GameState matched))
+                        {
+                            return matched;
+                        }
+                    }
+                }
+
+                // 若未匹配任何规则，回退到 legacy 检测保证向后兼容
+            }
+
+            return GetCurrentStateLegacy(bmp);
+        }
+
+        #region JSON 规则模型与加载
+
+        [DataContract]
+        private class StateRule
+        {
+            [DataMember(Name = "state")]
+            public string State { get; set; }
+
+            [DataMember(Name = "checks")]
+            public List<ColorCheck> Checks { get; set; }
+        }
+
+        [DataContract]
+        private class ColorCheck
+        {
+            [DataMember(Name = "x")]
+            public int X { get; set; }
+
+            [DataMember(Name = "y")]
+            public int Y { get; set; }
+
+            // 支持 "F34A12" / "#F34A12" / "0xF34A12"
+            [DataMember(Name = "color")]
+            public string Color { get; set; }
+
+            // 容差，默认为 50（累加 RGB 分量差）
+            [DataMember(Name = "tolerance")]
+            public int Tolerance { get; set; } = 50;
+
+            // 非（not）标记：若为 true 则表示颜色不匹配时为通过
+            [DataMember(Name = "not")]
+            public bool Not { get; set; } = false;
+        }
+
+        private List<StateRule> LoadRules(string path)
+        {
+            try
+            {
+                if (!File.Exists(path)) return null;
+                using (var fs = File.OpenRead(path))
+                {
+                    var ser = new DataContractJsonSerializer(typeof(List<StateRule>));
+                    var obj = ser.ReadObject(fs) as List<StateRule>;
+                    return obj ?? new List<StateRule>();
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region 规则评估与工具函数
+
+        private bool EvaluateRule(StateRule rule, Bitmap bmp)
+        {
+            if (rule?.Checks == null || bmp == null) return false;
+            foreach (var c in rule.Checks)
+            {
+                int expectedInt;
+                if (!TryParseHexColor(c.Color, out expectedInt))
+                {
+                    return false; // 规则配置错误，放弃该规则
+                }
+
+                bool match = CheckColorFromBitmap(_context, bmp, c.X, c.Y, expectedInt, c.Tolerance);
+                // 如果设置了 not，则要求“不匹配”才能通过该项
+                if (c.Not)
+                {
+                    if (match) return false;
+                }
+                else
+                {
+                    if (!match) return false;
+                }
+            }
+            return true;
+        }
+
+        private bool TryParseHexColor(string s, out int colorInt)
+        {
+            colorInt = 0;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            var str = s.Trim();
+            if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                str = str.Substring(2);
+            if (str.StartsWith("#")) str = str.Substring(1);
+            if (str.Length != 6) return false;
+            try
+            {
+                colorInt = Convert.ToInt32(str, 16);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region 原始硬编码检测（legacy，保留以兼容现有逻辑）
+
+        private GameState GetCurrentStateLegacy(Bitmap bmp)
+        {
+            if (!_context.IsValid) return GameState.UnKnown;
+
+            if ((CheckColorFromBitmap(_context, bmp, 780, 380, 0xF34A12) && CheckColorFromBitmap(_context, bmp, 780, 760, 0x5388D2) && CheckColorFromBitmap(_context, bmp, 900, 760, 0x62E200)) ||
+                (CheckColorFromBitmap(_context, bmp, 820, 330, 0xF24710) && CheckColorFromBitmap(_context, bmp, 820, 760, 0xD2D2D2) && CheckColorFromBitmap(_context, bmp, 960, 760, 0xFFFFFF)))
             {
                 return GameState.LevelChallengingWithTipScreen;
             }
             // 关卡挑战中界面
-            if (CheckColor(_context, 1910, 40, 0xB1814A) && CheckColor(_context, 13, 40, 0xB1814A))
+            if (CheckColorFromBitmap(_context, bmp, 1910, 40, 0xB1814A) && CheckColorFromBitmap(_context, bmp, 13, 40, 0xB1814A))
             {
 
                 return GameState.LevelChallengingScreen;
             }
             
             // 关卡挑战中遇到提示界面
-            if (CheckColor(_context, 1658, 40, 0x6A573C) && CheckColor(_context, 13, 40, 0x62482E))
+            if (CheckColorFromBitmap(_context, bmp, 1658, 40, 0x6A573C) && CheckColorFromBitmap(_context, bmp, 13, 40, 0x62482E))
             {
                 // 关卡设置界面
-                if (CheckColor(_context, 580, 240, 0xBE945B) && CheckColor(_context, 550, 380, 0x9F7843))
+                if (CheckColorFromBitmap(_context, bmp, 580, 240, 0xBE945B) && CheckColorFromBitmap(_context, bmp, 550, 380, 0x9F7843))
                 {
                     return GameState.LevelSettingScreen;
                 }
             }
 
-            if (CheckColor(_context, 722, 383, 0x6397D8) && CheckColor(_context, 1213, 383, 0x6397D8) && CheckColor(_context, 988, 118, 0xFFFFFF))
+            if (CheckColorFromBitmap(_context, bmp, 722, 383, 0x6397D8) && CheckColorFromBitmap(_context, bmp, 1213, 383, 0x6397D8) && CheckColorFromBitmap(_context, bmp, 988, 118, 0xFFFFFF))
                 return GameState.LevelFailedScreen;
 
 
 
             // 收集活动相关界面需要优先判断
-            if (CheckColor(_context, 960, 180, 0x121417) && CheckColor(_context, 750, 60, 0x121417) && CheckColor(_context, 1130, 200, 0x121417) && CheckColor(_context, 1725, 500, 0x121417))
+            if (CheckColorFromBitmap(_context, bmp, 960, 180, 0x121417) && CheckColorFromBitmap(_context, bmp, 750, 60, 0x121417) && CheckColorFromBitmap(_context, bmp, 1130, 200, 0x121417) && CheckColorFromBitmap(_context, bmp, 1725, 500, 0x121417))
             {
-                if (CheckColor(_context, 884, 1000, 0x67E400) && CheckColor(_context, 1037, 1000, 0x67E400))
+                if (CheckColorFromBitmap(_context, bmp, 884, 1000, 0x67E400) && CheckColorFromBitmap(_context, bmp, 1037, 1000, 0x67E400))
                     return GameState.ChestsOpenedScreen;
 
-                if (!CheckColor(_context, 828, 600, 0x121417) && !CheckColor(_context, 1130, 600, 0x121417))
+                if (!CheckColorFromBitmap(_context, bmp, 828, 600, 0x121417) && !CheckColorFromBitmap(_context, bmp, 1130, 600, 0x121417))
                     return GameState.TwoChestsScreen;
 
-                if (!CheckColor(_context, 660, 600, 0x121417) && !CheckColor(_context, 1260, 600, 0x121417))
+                if (!CheckColorFromBitmap(_context, bmp, 660, 600, 0x121417) && !CheckColorFromBitmap(_context, bmp, 1260, 600, 0x121417))
                     return GameState.ThreeChestsScreen;
             }
 
             // 主界面判断
-            if (CheckColor(_context, 966, 945, 0xFFFFFF) && CheckColor(_context, 1382, 942, 0xFFFFFF) && CheckColor(_context, 80, 186, 0xC4E8EB))
+            if (CheckColorFromBitmap(_context, bmp, 966, 945, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 1382, 942, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 80, 186, 0xC4E8EB))
                 return GameState.GameMainScreen;
 
             // 地图搜索相关界面
-            if (CheckColor(_context, 983, 48, 0x385373) && CheckColor(_context, 778, 43, 0x578CD4))
+            if (CheckColorFromBitmap(_context, bmp, 983, 48, 0x385373) && CheckColorFromBitmap(_context, bmp, 778, 43, 0x578CD4))
             {
-                if (CheckColor(_context, 962, 837, 0x409FFF))
+                if (CheckColorFromBitmap(_context, bmp, 962, 837, 0x409FFF))
                     return GameState.LevelSearchedScreen;
                 return GameState.LevelSearchScreen;
             }
 
-            if (CheckColor(_context, 68, 54, 0xFFFFFF))
+            if (CheckColorFromBitmap(_context, bmp, 68, 54, 0xFFFFFF))
             {
                 // 地图选择界面
-                if (CheckColor(_context, 273, 432, 0xFFD500) && CheckColor(_context, 1649, 432, 0xFFD500) && CheckColor(_context, 1313, 960, 0xFF3400))
+                if (CheckColorFromBitmap(_context, bmp, 273, 432, 0xFFD500) && CheckColorFromBitmap(_context, bmp, 1649, 432, 0xFFD500) && CheckColorFromBitmap(_context, bmp, 1313, 960, 0xFF3400))
                     return GameState.LevelSelectionScreen;
 
                 // 难度选择界面
-                if (CheckColor(_context, 716, 627, 0x9F7842) && CheckColor(_context, 1049, 627, 0x9F7842)
-                    && CheckColor(_context, 1388, 627, 0x9F7842))
+                if (CheckColorFromBitmap(_context, bmp, 716, 627, 0x9F7842) && CheckColorFromBitmap(_context, bmp, 1049, 627, 0x9F7842)
+                    && CheckColorFromBitmap(_context, bmp, 1388, 627, 0x9F7842))
                     return GameState.LevelDifficultySelectionScreen;
 
-                if (CheckColor(_context, 820, 40, 0x804A24) && CheckColor(_context, 1200, 40, 0x804A24))
+                if (CheckColorFromBitmap(_context, bmp, 820, 40, 0x804A24) && CheckColorFromBitmap(_context, bmp, 1200, 40, 0x804A24))
                 {
                     // 简单模式选择界面
-                    if (CheckColor(_context, 720, 50, 0xF2C776))
+                    if (CheckColorFromBitmap(_context, bmp, 720, 50, 0xF2C776))
                         return GameState.LevelEasyModeSelectionScreen;
 
                     // 中级模式选择界面
-                    if (CheckColor(_context, 720, 50, 0xC6DFEB))
+                    if (CheckColorFromBitmap(_context, bmp, 720, 50, 0xC6DFEB))
                         return GameState.LevelMediumModeSelectionScreen;
 
                     // 困难模式选择界面
-                    if (CheckColor(_context, 720, 50, 0xFFED00))
+                    if (CheckColorFromBitmap(_context, bmp, 720, 50, 0xFFED00))
                         return GameState.LevelHardModeSelectionScreen;
                 }
 
                 // 英雄选择界面
-                if (CheckColor(_context, 1601, 1005, 0xFFFFFF) && CheckColor(_context, 636, 51, 0xFFFFFF) && CheckColor(_context, 1900, 1060, 0x050505))
+                if (CheckColorFromBitmap(_context, bmp, 1601, 1005, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 636, 51, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 1900, 1060, 0x050505))
                     return GameState.HeroSelectionScreen;
 
-                if (CheckColor(_context, 750, 60, 0x996633) && CheckColor(_context, 1190, 60, 0x996633))
+                if (CheckColorFromBitmap(_context, bmp, 750, 60, 0x996633) && CheckColorFromBitmap(_context, bmp, 1190, 60, 0x996633))
                 {
-                    if (CheckColor(_context, 600, 320, 0xE2E2E2))
+                    if (CheckColorFromBitmap(_context, bmp, 600, 320, 0xE2E2E2))
                         return GameState.EventsScreen;
                     else
                         return GameState.EventInfoScreen;
                 }
 
                 // 收集活动主界面
-                if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF) || CheckColor(_context, 750, 60, 0x912DC9))
-                    && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF) || CheckColor(_context, 1100, 60, 0x912DC9)))
+                if ((CheckColorFromBitmap(_context, bmp, 750, 60, 0xBF330B) || CheckColorFromBitmap(_context, bmp, 750, 60, 0xCD78FF) || CheckColorFromBitmap(_context, bmp, 750, 60, 0x912DC9))
+                    && (CheckColorFromBitmap(_context, bmp, 1100, 60, 0xBF330B) || CheckColorFromBitmap(_context, bmp, 1100, 60, 0xCD78FF) || CheckColorFromBitmap(_context, bmp, 1100, 60, 0x912DC9)))
                     return GameState.CollectionActivitiesScreen;
 
                 // 可返回界面
@@ -216,46 +360,46 @@ namespace BTD6AutoCommunity.Core
             }
 
             // 关卡完成界面
-            if (CheckColor(_context, 555, 197, 0xFFFFFF))
+            if (CheckColorFromBitmap(_context, bmp, 555, 197, 0xFFFFFF))
             {
-                if (CheckColor(_context, 1365, 324, 0xFFFFFF) && CheckColor(_context, 791, 193, 0xF34A12))
+                if (CheckColorFromBitmap(_context, bmp, 1365, 324, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 791, 193, 0xF34A12))
                 {
                     return GameState.LevelSettlementScreen;
                 }
-                if (CheckColor(_context, 1221, 152, 0xFFFFFF) && CheckColor(_context, 585, 579, 0x5F93D7))
+                if (CheckColorFromBitmap(_context, bmp, 1221, 152, 0xFFFFFF) && CheckColorFromBitmap(_context, bmp, 585, 579, 0x5F93D7))
                 {
                     return GameState.LevelPassedScreen;
                 }
             }
 
-            if (CheckColor(_context, 1910, 40, 0x543E2A) && CheckColor(_context, 13, 40, 0x543E2A))
+            if (CheckColorFromBitmap(_context, bmp, 1910, 40, 0x543E2A) && CheckColorFromBitmap(_context, bmp, 13, 40, 0x543E2A))
             {
                 return GameState.LevelUpgradingScreen;
             }
 
-
-            if (CheckColor(_context, 1080, 400, 0x71E800) && CheckColor(_context, 1080, 500, 0x6095D7) && CheckColor(_context, 1080, 725, 0x69E500))
+            if (CheckColorFromBitmap(_context, bmp, 1080, 400, 0x71E800) && CheckColorFromBitmap(_context, bmp, 1080, 500, 0x6095D7) && CheckColorFromBitmap(_context, bmp, 1080, 725, 0x69E500))
                 return GameState.LevelTipScreen;
 
             // 收集活动可开箱界面
-            if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF) || CheckColor(_context, 750, 60, 0x912DC9)) 
-                && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF) || CheckColor(_context, 1100, 60, 0x912DC9))
-                && CheckColor(_context, 885, 681, 0x67E200))
+            if ((CheckColorFromBitmap(_context, bmp, 750, 60, 0xBF330B) || CheckColorFromBitmap(_context, bmp, 750, 60, 0xCD78FF) || CheckColorFromBitmap(_context, bmp, 750, 60, 0x912DC9))
+                && (CheckColorFromBitmap(_context, bmp, 1100, 60, 0xBF330B) || CheckColorFromBitmap(_context, bmp, 1100, 60, 0xCD78FF) || CheckColorFromBitmap(_context, bmp, 1100, 60, 0x912DC9))
+                && CheckColorFromBitmap(_context, bmp, 885, 681, 0x67E200))
                 return GameState.CollectionActivitiesAvailableScreen;
 
-            if (CheckColor(_context, 50, 50, 0x010001) && CheckColor(_context, 1870, 50, 0x010001) 
-                && CheckColor(_context, 750, 200, 0x991112) && CheckColor(_context, 1150, 200, 0x991112))
+            if (CheckColorFromBitmap(_context, bmp, 50, 50, 0x010001) && CheckColorFromBitmap(_context, bmp, 1870, 50, 0x010001) 
+                && CheckColorFromBitmap(_context, bmp, 750, 200, 0x991112) && CheckColorFromBitmap(_context, bmp, 1150, 200, 0x991112))
                 return GameState.InstaScreen;
 
-            if (CheckColor(_context, 880, 830, 0x61E200) && CheckColor(_context, 700, 350, 0xF34A12) && 
-                CheckColor(_context, 500, 390, 0x6599D9) && CheckColor(_context, 830, 570, 0xFFD200))
+            if (CheckColorFromBitmap(_context, bmp, 880, 830, 0x61E200) && CheckColorFromBitmap(_context, bmp, 700, 350, 0xF34A12) && 
+                CheckColorFromBitmap(_context, bmp, 500, 390, 0x6599D9) && CheckColorFromBitmap(_context, bmp, 830, 570, 0xFFD200))
                 return GameState.RaceResultsScreen;
 
-            if (CheckColor(_context, 500, 140, 0x6B1000) && CheckColor(_context, 800, 205, 0x118FB3) &&
-                CheckColor(_context, 1400, 140, 0x6B1000) && CheckColor(_context, 1150, 205, 0x118FB3))
+            if (CheckColorFromBitmap(_context, bmp, 500, 140, 0x6B1000) && CheckColorFromBitmap(_context, bmp, 800, 205, 0x118FB3) &&
+                CheckColorFromBitmap(_context, bmp, 1400, 140, 0x6B1000) && CheckColorFromBitmap(_context, bmp, 1150, 205, 0x118FB3))
                 return GameState.BossResultsScreen;
             return GameState.UnKnown;
         }
 
+        #endregion
     }
 }

--- a/BTD6AutoCommunity/Core/GameStateMachine.cs
+++ b/BTD6AutoCommunity/Core/GameStateMachine.cs
@@ -149,10 +149,10 @@ namespace BTD6AutoCommunity.Core
                 if (CheckColor(_context, 884, 1000, 0x67E400) && CheckColor(_context, 1037, 1000, 0x67E400))
                     return GameState.ChestsOpenedScreen;
 
-                if (!CheckColor(_context, 828, 537, 0x121417) && !CheckColor(_context, 1130, 537, 0x121417))
+                if (!CheckColor(_context, 828, 600, 0x121417) && !CheckColor(_context, 1130, 600, 0x121417))
                     return GameState.TwoChestsScreen;
 
-                if (!CheckColor(_context, 677, 537, 0x121417) && !CheckColor(_context, 1277, 537, 0x121417))
+                if (!CheckColor(_context, 660, 600, 0x121417) && !CheckColor(_context, 1260, 600, 0x121417))
                     return GameState.ThreeChestsScreen;
             }
 
@@ -195,7 +195,7 @@ namespace BTD6AutoCommunity.Core
                 }
 
                 // 英雄选择界面
-                if (CheckColor(_context, 1601, 1005, 0xFFFFFF) && CheckColor(_context, 636, 51, 0xFFFFFF))
+                if (CheckColor(_context, 1601, 1005, 0xFFFFFF) && CheckColor(_context, 636, 51, 0xFFFFFF) && CheckColor(_context, 1900, 1060, 0x050505))
                     return GameState.HeroSelectionScreen;
 
                 if (CheckColor(_context, 750, 60, 0x996633) && CheckColor(_context, 1190, 60, 0x996633))
@@ -207,8 +207,8 @@ namespace BTD6AutoCommunity.Core
                 }
 
                 // 收集活动主界面
-                if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF))
-                    && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF)))
+                if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF) || CheckColor(_context, 750, 60, 0x912DC9))
+                    && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF) || CheckColor(_context, 1100, 60, 0x912DC9)))
                     return GameState.CollectionActivitiesScreen;
 
                 // 可返回界面
@@ -238,12 +238,13 @@ namespace BTD6AutoCommunity.Core
                 return GameState.LevelTipScreen;
 
             // 收集活动可开箱界面
-            if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF)) 
-                && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF))
+            if ((CheckColor(_context, 750, 60, 0xBF330B) || CheckColor(_context, 750, 60, 0xCD78FF) || CheckColor(_context, 750, 60, 0x912DC9)) 
+                && (CheckColor(_context, 1100, 60, 0xBF330B) || CheckColor(_context, 1100, 60, 0xCD78FF) || CheckColor(_context, 1100, 60, 0x912DC9))
                 && CheckColor(_context, 885, 681, 0x67E200))
                 return GameState.CollectionActivitiesAvailableScreen;
 
-            if (CheckColor(_context, 760, 660, 0xF34E13) && CheckColor(_context, 1130, 660, 0xF45417))
+            if (CheckColor(_context, 50, 50, 0x010001) && CheckColor(_context, 1870, 50, 0x010001) 
+                && CheckColor(_context, 750, 200, 0x991112) && CheckColor(_context, 1150, 200, 0x991112))
                 return GameState.InstaScreen;
 
             if (CheckColor(_context, 880, 830, 0x61E200) && CheckColor(_context, 700, 350, 0xF34A12) && 

--- a/BTD6AutoCommunity/Core/GameVisionRecognizer.cs
+++ b/BTD6AutoCommunity/Core/GameVisionRecognizer.cs
@@ -248,7 +248,7 @@ namespace BTD6AutoCommunity.Core
         {
             if (index == -1) return false;
             System.Drawing.Point point = Constants.UpgradeYellowPosition[index * 5 + 5 - p];
-            Debug.WriteLine($"point: {point}");
+            //Debug.WriteLine($"point: {point}");
             Color c1 = GetGameColor(context, point);
             if (c1.B < 5 && c1.R > 40 && c1.G > 220)
             {
@@ -294,12 +294,12 @@ namespace BTD6AutoCommunity.Core
 
         public static bool IsLeftUpgrading(GameContext context)
         {
-            return CheckColor(context, 415, 120, 0xbe925a) && CheckColor(context, 415, 870, 0xb48149);
+            return CheckColor(context, 415, 120, 0xbe925a) && CheckColor(context, 415, 870, 0xb48149) && CheckColor(context, 400, 84, 0x623811);
         }
 
         public static bool IsRightUpgrading(GameContext context)
         {
-            return CheckColor(context, 1260, 200, 0xbe925a) && CheckColor(context, 1260, 870, 0xb48149);
+            return CheckColor(context, 1260, 200, 0xbe925a) && CheckColor(context, 1260, 870, 0xb48149) && CheckColor(context, 1620, 84, 0x623811);
         }
 
         public static int AbilityRgbSum(GameContext context, int index)
@@ -312,7 +312,12 @@ namespace BTD6AutoCommunity.Core
         {
             if (CheckColor(context, 630, 800, 0xFFFFFF)) return new System.Drawing.Point(630, 810);
             return new System.Drawing.Point(740, 810);
+        }
 
+        public static System.Drawing.Point GetSettlementScreenReturnPosition(GameContext context)
+        {
+            if (CheckColor(context, 840, 840, 0xFFFFFF)) return new System.Drawing.Point(840, 850);
+            return new System.Drawing.Point(720, 850);
         }
 
         public static System.Drawing.Point GetRestartPos(GameContext context)

--- a/BTD6AutoCommunity/Core/GameVisionRecognizer.cs
+++ b/BTD6AutoCommunity/Core/GameVisionRecognizer.cs
@@ -61,7 +61,7 @@ namespace BTD6AutoCommunity.Core
             }
         }
 
-        public static int GetMapEreaIndex(GameContext context, System.Drawing.Point mapPos)
+        public static int GetMapEreaIndex(System.Drawing.Point mapPos)
         {
             if (mapPos.Y < 430 && mapPos.Y > 120)
             {
@@ -76,6 +76,31 @@ namespace BTD6AutoCommunity.Core
                 if (mapPos.X < 1600) return 5;
             }
             return -1;
+        }
+
+        public static Badges GetMapBadges(GameContext context, int mapEreaId, Bitmap bitmap)
+        {
+            if (mapEreaId == -1) return null;
+            Badges badges = new Badges();
+            int deltaX = (mapEreaId % 3) * 423;
+            int deltaY = (mapEreaId / 3) * 313;
+            badges.SetBadgeStatus(LevelDifficulties.Easy, LevelModes.Standard, !CheckColorFromBitmap(context, bitmap, badges.EasyStandardPos.X + deltaX, badges.EasyStandardPos.Y + deltaY, new List<int> { 0xA88859, 0xA9B9C4, 0xBE7813}));
+            badges.SetBadgeStatus(LevelDifficulties.Medium, LevelModes.Standard, !CheckColorFromBitmap(context, bitmap, badges.MediumStandardPos.X + deltaX, badges.MediumStandardPos.Y + deltaY, new List<int> { 0xA88859, 0xA9B9C4, 0xBE7813 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.Standard, !CheckColorFromBitmap(context, bitmap, badges.HardStandardPos.X + deltaX, badges.HardStandardPos.Y + deltaY, new List<int> { 0xA88859, 0xA9B9C4, 0xBE7813 }));
+            badges.SetBadgeStatus(LevelDifficulties.Easy, LevelModes.PrimaryOnly, !CheckColorFromBitmap(context, bitmap, badges.PrimaryOnlyPos.X + deltaX, badges.PrimaryOnlyPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Medium, LevelModes.MilitaryOnly, !CheckColorFromBitmap(context, bitmap, badges.MilitaryOnlyPos.X + deltaX, badges.MilitaryOnlyPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.MagicMonkeysOnly, !CheckColorFromBitmap(context, bitmap, badges.MagicMonkeysOnlyPos.X + deltaX, badges.MagicMonkeysOnlyPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Easy, LevelModes.Deflation, !CheckColorFromBitmap(context, bitmap, badges.DeflationPos.X + deltaX, badges.DeflationPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Medium, LevelModes.Apopalypse, !CheckColorFromBitmap(context, bitmap, badges.ApopalypsePos.X + deltaX, badges.ApopalypsePos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Medium, LevelModes.Reverse, !CheckColorFromBitmap(context, bitmap, badges.ReversePos.X + deltaX, badges.ReversePos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.HalfCash, !CheckColorFromBitmap(context, bitmap, badges.HalfCashPos.X + deltaX, badges.HalfCashPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.DoubleHpMoabs, !CheckColorFromBitmap(context, bitmap, badges.DoubleHpMoabsPos.X + deltaX, badges.DoubleHpMoabsPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.AlternateBloonsRounds, !CheckColorFromBitmap(context, bitmap, badges.AlternateBloonsRoundsPos.X + deltaX, badges.AlternateBloonsRoundsPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.Impoppable, !CheckColorFromBitmap(context, bitmap, badges.ImpoppablePos.X + deltaX, badges.ImpoppablePos.Y + deltaY, new List<int> { 0xA88859, 0xA9B9C4, 0xBE7813 }));
+            badges.SetBadgeStatus(LevelDifficulties.Hard, LevelModes.CHIMPS, !CheckColorFromBitmap(context, bitmap, badges.CHIMPSPos.X + deltaX, badges.CHIMPSPos.Y + deltaY, new List<int> { 0xB08959, 0xA9BCCA, 0xC37503 }));
+
+            return badges;
+
         }
 
         public static System.Drawing.Point GetHeroPosition(GameContext context, Heroes heroName)
@@ -219,7 +244,15 @@ namespace BTD6AutoCommunity.Core
             );
         }
 
-        private static Color GetGameColor(GameContext context, System.Drawing.Point basePoint)
+        private static Color GetGameColorFromBitmap(GameContext context, Bitmap bmp, System.Drawing.Point basePoint)
+        {
+            return bmp.GetPixel(
+                (int)(basePoint.X * context.ResolutionScale),
+                (int)(basePoint.Y * context.ResolutionScale)
+            );
+        }
+
+        private static Color GetGameColorFromScreen(GameContext context, System.Drawing.Point basePoint)
         {
             using (Bitmap bitmap = new Bitmap(1, 1))
             {
@@ -232,9 +265,67 @@ namespace BTD6AutoCommunity.Core
             }
         }
 
-        public static bool CheckColor(GameContext context, int x, int y, int expectedColor)
+        public static bool CheckColorFromBitmap(GameContext context, Bitmap bmp, int x, int y, int expectedColor, int tolerance = 50)
         {
-            Color color = GetGameColor(context, new System.Drawing.Point(x, y));
+            Color color = GetGameColorFromBitmap(context, bmp, new System.Drawing.Point(x, y));
+            Color expected = Color.FromArgb(expectedColor >> 16, (expectedColor >> 8) & 0xFF, expectedColor & 0xFF);
+
+            int diff = Math.Abs(color.R - expected.R)
+                     + Math.Abs(color.G - expected.G)
+                     + Math.Abs(color.B - expected.B);
+
+            return diff < tolerance;
+        }
+
+        public static bool CheckColorFromBitmap(GameContext context, Bitmap bmp, System.Drawing.Point point, int expectedColor, int tolerance = 50)
+        {
+            Color color = GetGameColorFromBitmap(context, bmp, point);
+            Color expected = Color.FromArgb(expectedColor >> 16, (expectedColor >> 8) & 0xFF, expectedColor & 0xFF);
+            int diff = Math.Abs(color.R - expected.R)
+                     + Math.Abs(color.G - expected.G)
+                     + Math.Abs(color.B - expected.B);
+            return diff < tolerance;
+        }
+
+        public static bool CheckColorFromBitmap(GameContext context, Bitmap bmp, int x, int y, List<int> expectedColors)
+        {
+            Color color = GetGameColorFromBitmap(context, bmp, new System.Drawing.Point(x, y));
+            foreach (var expectedColor in expectedColors)
+            {
+                Color expected = Color.FromArgb(expectedColor >> 16, (expectedColor >> 8) & 0xFF, expectedColor & 0xFF);
+                int diff = Math.Abs(color.R - expected.R)
+                         + Math.Abs(color.G - expected.G)
+                         + Math.Abs(color.B - expected.B);
+                if (diff < 50)
+                {
+                    Debug.WriteLine($"Found matching color at ({x}, {y}): R={color.R}, G={color.G}, B={color.B}");
+                    return true;
+                }
+                Debug.WriteLine($"No match for color at ({x}, {y}): R={color.R}, G={color.G}, B={color.B} vs Expected R={expected.R}, G={expected.G}, B={expected.B} with diff {diff}");
+            }
+            return false;
+        }
+
+        public static bool CheckColorFromBitmap(GameContext context, Bitmap bmp, System.Drawing.Point point, List<int> expectedColors)
+        {
+            Color color = GetGameColorFromBitmap(context, bmp, point);
+            foreach (var expectedColor in expectedColors)
+            {
+                Color expected = Color.FromArgb(expectedColor >> 16, (expectedColor >> 8) & 0xFF, expectedColor & 0xFF);
+                int diff = Math.Abs(color.R - expected.R)
+                         + Math.Abs(color.G - expected.G)
+                         + Math.Abs(color.B - expected.B);
+                if (diff < 50)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool CheckColorFromScreen(GameContext context, int x, int y, int expectedColor)
+        {
+            Color color = GetGameColorFromScreen(context, new System.Drawing.Point(x, y));
             Color expected = Color.FromArgb(expectedColor >> 16, (expectedColor >> 8) & 0xFF, expectedColor & 0xFF);
 
             int diff = Math.Abs(color.R - expected.R)
@@ -249,7 +340,7 @@ namespace BTD6AutoCommunity.Core
             if (index == -1) return false;
             System.Drawing.Point point = Constants.UpgradeYellowPosition[index * 5 + 5 - p];
             //Debug.WriteLine($"point: {point}");
-            Color c1 = GetGameColor(context, point);
+            Color c1 = GetGameColorFromScreen(context, point);
             if (c1.B < 5 && c1.R > 40 && c1.G > 220)
             {
                 return true;
@@ -259,7 +350,7 @@ namespace BTD6AutoCommunity.Core
 
         public static bool IsInGame(GameContext context)
         {
-            if (CheckColor(context, 1910, 40, 0xB1814A) && CheckColor(context, 13, 40, 0xB1814A))
+            if (CheckColorFromScreen(context, 1910, 40, 0xB1814A) && CheckColorFromScreen(context, 13, 40, 0xB1814A))
             {
                 return true;
             }
@@ -268,8 +359,8 @@ namespace BTD6AutoCommunity.Core
 
         public static bool IsMonkeyDeploy(GameContext context)
         {
-            Color c1 = GetGameColor(context, new System.Drawing.Point(1600, 120));
-            Color c2 = GetGameColor(context, new System.Drawing.Point(1600, 98));
+            Color c1 = GetGameColorFromScreen(context, new System.Drawing.Point(1600, 120));
+            Color c2 = GetGameColorFromScreen(context, new System.Drawing.Point(1600, 98));
             if (c1.R > 250 && c1.G > 250 && c1.B > 250
                 && Math.Abs(c2.R - 0xff) < 20 && Math.Abs(c2.G - 0x79) < 20 && Math.Abs(c2.B - 0x00) < 20)
             {
@@ -280,8 +371,8 @@ namespace BTD6AutoCommunity.Core
 
         public static bool IsHeroDeploy(GameContext context)
         {
-            Color c1 = GetGameColor(context, new System.Drawing.Point(1757, 272));
-            Color c2 = GetGameColor(context, new System.Drawing.Point(1670, 274));
+            Color c1 = GetGameColorFromScreen(context, new System.Drawing.Point(1757, 272));
+            Color c2 = GetGameColorFromScreen(context, new System.Drawing.Point(1670, 274));
             if ((c1.R > 245 && c1.B < 10) || (c2.R > 245 && c2.B < 10))
             {
                 return true;
@@ -294,37 +385,37 @@ namespace BTD6AutoCommunity.Core
 
         public static bool IsLeftUpgrading(GameContext context)
         {
-            return CheckColor(context, 415, 120, 0xbe925a) && CheckColor(context, 415, 870, 0xb48149) && CheckColor(context, 400, 84, 0x623811);
+            return CheckColorFromScreen(context, 415, 120, 0xbe925a) && CheckColorFromScreen(context, 415, 870, 0xb48149) && CheckColorFromScreen(context, 400, 84, 0x623811);
         }
 
         public static bool IsRightUpgrading(GameContext context)
         {
-            return CheckColor(context, 1260, 200, 0xbe925a) && CheckColor(context, 1260, 870, 0xb48149) && CheckColor(context, 1620, 84, 0x623811);
+            return CheckColorFromScreen(context, 1260, 200, 0xbe925a) && CheckColorFromScreen(context, 1260, 870, 0xb48149) && CheckColorFromScreen(context, 1620, 84, 0x623811);
         }
 
         public static int AbilityRgbSum(GameContext context, int index)
         {
-            Color c1 = GetGameColor(context, new System.Drawing.Point(200 + index * 100, 1035));
+            Color c1 = GetGameColorFromScreen(context, new System.Drawing.Point(200 + index * 100, 1035));
             return c1.R + c1.G + c1.B;
         }
 
         public static System.Drawing.Point GetFailedScreenReturnPosition(GameContext context)
         {
-            if (CheckColor(context, 630, 800, 0xFFFFFF)) return new System.Drawing.Point(630, 810);
+            if (CheckColorFromScreen(context, 630, 800, 0xFFFFFF)) return new System.Drawing.Point(630, 810);
             return new System.Drawing.Point(740, 810);
         }
 
         public static System.Drawing.Point GetSettlementScreenReturnPosition(GameContext context)
         {
-            if (CheckColor(context, 840, 840, 0xFFFFFF)) return new System.Drawing.Point(840, 850);
+            if (CheckColorFromScreen(context, 840, 840, 0xFFFFFF)) return new System.Drawing.Point(840, 850);
             return new System.Drawing.Point(720, 850);
         }
 
         public static System.Drawing.Point GetRestartPos(GameContext context)
         {
-            Color c1 = GetGameColor(context, new System.Drawing.Point(850, 765));
-            Color c2 = GetGameColor(context, new System.Drawing.Point(960, 765));
-            Color c3 = GetGameColor(context, new System.Drawing.Point(1330, 800));
+            Color c1 = GetGameColorFromScreen(context, new System.Drawing.Point(850, 765));
+            Color c2 = GetGameColorFromScreen(context, new System.Drawing.Point(960, 765));
+            Color c3 = GetGameColorFromScreen(context, new System.Drawing.Point(1330, 800));
             if (Math.Abs(c1.R - 0x71) < 30 && Math.Abs(c1.G - 0xe8) < 30 && Math.Abs(c1.B - 0x00) < 30)
             {
                 return new System.Drawing.Point(850, 815);
@@ -346,7 +437,7 @@ namespace BTD6AutoCommunity.Core
 
         public static int AbilityReady(GameContext context, int index)
         {
-            Color c1 = GetGameColor(context, new System.Drawing.Point(200 + index * 100, 1035));
+            Color c1 = GetGameColorFromScreen(context, new System.Drawing.Point(200 + index * 100, 1035));
             return c1.R + c1.G + c1.B;
         }
     }

--- a/BTD6AutoCommunity/Core/LevelDataMonitor.cs
+++ b/BTD6AutoCommunity/Core/LevelDataMonitor.cs
@@ -217,7 +217,7 @@ namespace BTD6AutoCommunity.Core
                     tryGet++;
                     Cv2.MatchTemplate(image, template.Value, result, TemplateMatchModes.SqDiffNormed, mask);
                     Cv2.MinMaxLoc(result, out double minVal, out double maxVal, out OpenCvSharp.Point minLoc, out OpenCvSharp.Point maxLoc);
-                    //Debug.WriteLine($"num: {template.Key} minVal: {minVal}");
+                    Debug.WriteLine($"num: {template.Key} minVal: {minVal}");
                     if (minVal <= 0.075)
                     {
                         digits.Add((minLoc.X, template.Key));

--- a/BTD6AutoCommunity/Core/ScreenshotCapturer.cs
+++ b/BTD6AutoCommunity/Core/ScreenshotCapturer.cs
@@ -1,0 +1,188 @@
+﻿using OpenCvSharp;
+using OpenCvSharp.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTD6AutoCommunity.Core
+{
+    /// <summary>
+    /// 负责与屏幕截取相关的功能：按游戏窗口区域或基于游戏坐标的区域截屏，
+    /// 提供线程安全的内部缓存并负责释放旧 Bitmap，支持返回 Bitmap 副本或 OpenCvSharp.Mat。
+    /// </summary>
+    public class ScreenCapturer : IDisposable
+    {
+        private readonly GameContext _context;
+        // 私有缓存，使用 Interlocked.Exchange 原子替换并释放旧对象
+        private Bitmap _screenshot;
+        private bool _disposed;
+
+        public ScreenCapturer(GameContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        /// <summary>
+        /// 当前缓存的截图（只读）。注意：不要直接对该实例调用 Dispose/修改，使用 GetScreenshotClone 安全获取副本。
+        /// </summary>
+        public Bitmap CurrentScreenshot => _screenshot;
+
+        /// <summary>
+        /// 捕获整个游戏窗口（基于 GameContext.CurrentResolution / ClientTopLeft）。
+        /// 返回一个 Bitmap 副本（调用者负责 Dispose）。
+        /// 内部也会原子替换保存最新截图并释放旧的缓存。
+        /// </summary>
+        public Bitmap CaptureFullAndGetClone()
+        {
+            EnsureNotDisposed();
+
+            if (!_context.IsValid) return null;
+            var screenArea = new Rectangle(
+                _context.ClientTopLeft.X,
+                _context.ClientTopLeft.Y,
+                _context.CurrentResolution.Width,
+                _context.CurrentResolution.Height
+            );
+
+            return CaptureAndSwap(screenArea);
+        }
+
+        /// <summary>
+        /// 捕获基于游戏逻辑坐标（base coordinates）的矩形区域（坐标以 BaseResolution 为基准）。
+        /// 返回 Bitmap 副本（调用者负责 Dispose）。
+        /// </summary>
+        public Bitmap CaptureGameRegionAndGetClone(Rectangle baseRect)
+        {
+            EnsureNotDisposed();
+
+            if (!_context.IsValid) return null;
+
+            // 将 baseRect（游戏坐标）转换为屏幕坐标区域
+            var topLeft = _context.ConvertGamePosition(new System.Drawing.Point(baseRect.X, baseRect.Y));
+            var scaledWidth = (int)(baseRect.Width * _context.ResolutionScale);
+            var scaledHeight = (int)(baseRect.Height * _context.ResolutionScale);
+            var screenArea = new Rectangle(topLeft.X, topLeft.Y, scaledWidth, scaledHeight);
+
+            return CaptureAndSwap(screenArea);
+        }
+
+        /// <summary>
+        /// 捕获整个游戏窗口并返回 OpenCvSharp.Mat（调用者负责 Dispose Mat）。
+        /// </summary>
+        public Mat CaptureFullAsMat()
+        {
+            var bmp = CaptureFullAndGetClone();
+            if (bmp == null) return null;
+            try
+            {
+                return BitmapConverter.ToMat(bmp);
+            }
+            finally
+            {
+                bmp.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// 捕获基于游戏逻辑坐标的区域并返回 Mat（调用者负责 Dispose）。
+        /// </summary>
+        public Mat CaptureGameRegionAsMat(Rectangle baseRect)
+        {
+            var bmp = CaptureGameRegionAndGetClone(baseRect);
+            if (bmp == null) return null;
+            try
+            {
+                return BitmapConverter.ToMat(bmp);
+            }
+            finally
+            {
+                bmp.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// 获取当前缓存截图的副本（调用者负责 Dispose）。
+        /// </summary>
+        public Bitmap GetScreenshotClone()
+        {
+            var bmp = _screenshot;
+            if (bmp == null) return null;
+            try
+            {
+                return (Bitmap)bmp.Clone();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 执行实际截屏并原子替换内部缓存，返回一个 Bitmap 副本（调用者负责 Dispose）。
+        /// </summary>
+        private Bitmap CaptureAndSwap(Rectangle screenArea)
+        {
+            // 防御性检查
+            if (screenArea.Width <= 0 || screenArea.Height <= 0) return null;
+
+            Bitmap newBmp = null;
+            try
+            {
+                newBmp = new Bitmap(screenArea.Width, screenArea.Height);
+                using (var g = Graphics.FromImage(newBmp))
+                {
+                    g.CopyFromScreen(screenArea.Location, System.Drawing.Point.Empty, screenArea.Size);
+                }
+
+                // 原子替换缓存并释放旧的 bitmap
+                var old = Interlocked.Exchange(ref _screenshot, newBmp);
+                if (old != null)
+                {
+                    try { old.Dispose(); } catch { /* 忽略释放异常 */ }
+                }
+
+                // 返回副本，避免调用者误释放内部缓存
+                return (Bitmap)newBmp.Clone();
+            }
+            catch
+            {
+                // 若创建或截取过程中抛出，确保释放新建但未缓存的 bitmap
+                try { newBmp?.Dispose(); } catch { }
+                throw;
+            }
+        }
+
+        private void EnsureNotDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(ScreenCapturer));
+        }
+
+        #region IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                var old = Interlocked.Exchange(ref _screenshot, null);
+                try { old?.Dispose(); } catch { }
+            }
+            _disposed = true;
+        }
+
+        ~ScreenCapturer()
+        {
+            Dispose(false);
+        }
+        #endregion
+    }
+}

--- a/BTD6AutoCommunity/GameObjects/GameEnums.cs
+++ b/BTD6AutoCommunity/GameObjects/GameEnums.cs
@@ -154,6 +154,7 @@ namespace BTD6AutoCommunity.GameObjects
         SunsetGulch = 80,
 
         // 专家图
+
         // 冰河之径
         GlacialTrail = 90,
         // 黑暗地下城
@@ -178,6 +179,8 @@ namespace BTD6AutoCommunity.GameObjects
         MuddyPuddles = 100,
         // #哎哟
         Ouch = 101,
+        // 棘手的轨道
+        TrickyTracks = 102,
 
         Unknown = 255
     }

--- a/BTD6AutoCommunity/GameObjects/GameEnums.cs
+++ b/BTD6AutoCommunity/GameObjects/GameEnums.cs
@@ -12,6 +12,8 @@ namespace BTD6AutoCommunity.GameObjects
         MonkeyMeadow = 0,
         // 循环
         InTheLoop = 1,
+        //三矿回合
+        ThreeMilesRound = 24,
         // 道路中间
         MiddleOfTheRoad = 2,
         // 水疗温泉
@@ -104,6 +106,8 @@ namespace BTD6AutoCommunity.GameObjects
         SpiceIslands = 51,
         // 夜光海湾
         LuminousCove = 52,
+        // 失落冰隙
+        LostCrevasse = 53,
 
         // 高级图
         // 城堡复仇
@@ -175,10 +179,10 @@ namespace BTD6AutoCommunity.GameObjects
         // #哎哟
         Ouch = 101,
 
-        Unkown = 255
+        Unknown = 255
     }
 
-    public enum LevelMode
+    public enum LevelModes
     {
         /// <summary>标准模式（默认游戏模式）</summary>
         Standard = 0,
@@ -214,15 +218,6 @@ namespace BTD6AutoCommunity.GameObjects
         Impoppable = 7,
 
         /// <summary>CHIMPS模式（无收入/能量/出售）</summary>
-        /// <remarks>
-        /// 规则限制：
-        /// C - No Continues       (无继续)
-        /// H - Heartslost         (心数限制)
-        /// I - No Income           (无额外收入)
-        /// M - No Monkeys Knowledge(无猴子知识)
-        /// P - No Powerups         (无强化道具)
-        /// S - No Selling          (无法出售塔)
-        /// </remarks>
         CHIMPS = 8,
 
         Unkown = 255
@@ -267,7 +262,7 @@ namespace BTD6AutoCommunity.GameObjects
 
     public enum Heroes
     {
-        Quincy = 0,
+        Quincy = 0, 
         Gwendolin = 1,
         StrikerJones = 2,
         ObynGreenfoot = 3,
@@ -283,7 +278,7 @@ namespace BTD6AutoCommunity.GameObjects
         Psi = 13,
         Geraldo = 14,
         Corvus = 15,
-
+        Silas = 16,
         Unkown = 255
     }
 

--- a/BTD6AutoCommunity/GameObjects/MapInfo.cs
+++ b/BTD6AutoCommunity/GameObjects/MapInfo.cs
@@ -1,0 +1,198 @@
+﻿using BTD6AutoCommunity.Core;
+using BTD6AutoCommunity.GameObjects;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BTD6AutoCommunity.GameObjects
+{
+    public class MapInfo
+    {
+        private Dictionary<Maps, Badges> mapBadges;
+
+        private Dictionary<Maps, bool> checkedMaps;
+        public MapInfo()
+        {
+            checkedMaps = new Dictionary<Maps, bool>();
+            mapBadges = new Dictionary<Maps, Badges>();
+            foreach (Maps map in Constants.MapsList)
+            {
+                checkedMaps[map] = false;
+                mapBadges[map] = new Badges();
+            }
+        }
+
+        public bool IsMapChecked(Maps map)
+        {
+            if (checkedMaps.ContainsKey(map))
+            {
+                return checkedMaps[map];
+            }
+            return false;
+        }
+
+        public void SetMapChecked(Maps map, bool isChecked)
+        {
+            if (checkedMaps.ContainsKey(map))
+            {
+                checkedMaps[map] = isChecked;
+            }
+        }
+
+        public void SetBadges(Maps map, Badges badges)
+        {
+            if (mapBadges.ContainsKey(map))
+            {
+                mapBadges[map] = badges;
+            }
+        }
+
+        public Badges GetBadges(Maps map)
+        {
+            if (mapBadges.ContainsKey(map))
+            {
+                return mapBadges[map];
+            }
+            return null;
+        }
+
+        public bool GetBadgeStatus(Maps map, LevelDifficulties difficulty, LevelModes mode)
+        {
+            if (!checkedMaps.ContainsKey(map))
+            {
+                return false;
+            }
+            if (mapBadges.ContainsKey(map))
+            {
+                return mapBadges[map].GetBadgeStatus(difficulty, mode);
+            }
+            return false;
+        }
+    }
+
+    public class Badges
+    {
+        private bool EasyStandard { get; set; }
+        private bool MediumStandard { get; set; }
+        private bool HardStandard { get; set; }
+        private bool PrimaryOnly { get; set; }
+        private bool MilitaryOnly { get; set; }
+        private bool MagicMonkeysOnly { get; set; }
+        private bool Deflation { get; set; }
+        private bool Apopalypse { get; set; }
+        private bool Reverse { get; set; }
+        private bool HalfCash { get; set; }
+        private bool DoubleHpMoabs { get; set; }
+        private bool AlternateBloonsRounds { get; set; }
+        private bool Impoppable { get; set; }
+        private bool CHIMPS { get; set; }
+
+        // Base Position:
+        public readonly Point EasyStandardPos = new Point(406, 366);
+        public readonly Point MediumStandardPos = new Point(492, 366);
+        public readonly Point HardStandardPos = new Point(580, 366);
+        public readonly Point PrimaryOnlyPos = new Point(382, 401);
+        public readonly Point MilitaryOnlyPos = new Point(466, 401);
+        public readonly Point MagicMonkeysOnlyPos = new Point(543, 377);
+        public readonly Point DeflationPos = new Point(436, 401);
+        public readonly Point ApopalypsePos = new Point(492, 401);
+        public readonly Point ReversePos = new Point(520, 401);
+        public readonly Point HalfCashPos = new Point(607, 401);
+        public readonly Point DoubleHpMoabsPos = new Point(550, 401);
+        public readonly Point AlternateBloonsRoundsPos = new Point(615, 377);
+        public readonly Point ImpoppablePos = new Point(666, 366);
+        public readonly Point CHIMPSPos = new Point(693, 401);
+
+        public Badges()
+        {
+            EasyStandard = false;
+            MediumStandard = false;
+            HardStandard = false;
+            PrimaryOnly = false;
+            MilitaryOnly = false;
+            MagicMonkeysOnly = false;
+            Deflation = false;
+            Apopalypse = false;
+            Reverse = false;
+            HalfCash = false;
+            DoubleHpMoabs = false;
+            AlternateBloonsRounds = false;
+            Impoppable = false;
+            CHIMPS = false;
+        }
+
+        public bool GetBadgeStatus(LevelDifficulties difficulty, LevelModes mode)
+        {
+            if (difficulty == LevelDifficulties.Easy && mode == LevelModes.Standard) return EasyStandard;
+            if (difficulty == LevelDifficulties.Medium && mode == LevelModes.Standard) return MediumStandard;
+            if (difficulty == LevelDifficulties.Hard && mode == LevelModes.Standard) return HardStandard;
+            if (mode == LevelModes.PrimaryOnly) return PrimaryOnly;
+            if (mode == LevelModes.MilitaryOnly) return MilitaryOnly;
+            if (mode == LevelModes.MagicMonkeysOnly) return MagicMonkeysOnly;
+            if (mode == LevelModes.Deflation) return Deflation;
+            if (mode == LevelModes.Apopalypse) return Apopalypse;
+            if (mode == LevelModes.Reverse) return Reverse;
+            if (mode == LevelModes.HalfCash) return HalfCash;
+            if (mode == LevelModes.DoubleHpMoabs) return DoubleHpMoabs;
+            if (mode == LevelModes.AlternateBloonsRounds) return AlternateBloonsRounds;
+            if (mode == LevelModes.Impoppable) return Impoppable;
+            if (mode == LevelModes.CHIMPS) return CHIMPS;
+            return false;
+        }
+
+        public void SetBadgeStatus(LevelDifficulties difficulty, LevelModes mode, bool status)
+        {
+            if (difficulty == LevelDifficulties.Easy && mode == LevelModes.Standard) EasyStandard = status;
+            else if (difficulty == LevelDifficulties.Medium && mode == LevelModes.Standard) MediumStandard = status;
+            else if (difficulty == LevelDifficulties.Hard && mode == LevelModes.Standard) HardStandard = status;
+            else if (mode == LevelModes.PrimaryOnly) PrimaryOnly = status;
+            else if (mode == LevelModes.MilitaryOnly) MilitaryOnly = status;
+            else if (mode == LevelModes.MagicMonkeysOnly) MagicMonkeysOnly = status;
+            else if (mode == LevelModes.Deflation) Deflation = status;
+            else if (mode == LevelModes.Apopalypse) Apopalypse = status;
+            else if (mode == LevelModes.Reverse) Reverse = status;
+            else if (mode == LevelModes.HalfCash) HalfCash = status;
+            else if (mode == LevelModes.DoubleHpMoabs) DoubleHpMoabs = status;
+            else if (mode == LevelModes.AlternateBloonsRounds) AlternateBloonsRounds = status;
+            else if (mode == LevelModes.Impoppable) Impoppable = status;
+            else if (mode == LevelModes.CHIMPS) CHIMPS = status;
+        }
+
+            //{ LevelModes.Standard, "标准" },
+            //{ LevelModes.PrimaryOnly, "仅初级" },
+            //{ LevelModes.Deflation, "放气" },
+            //{ LevelModes.MilitaryOnly, "仅军事" },
+            //{ LevelModes.Apopalypse, "天启" },
+            //{ LevelModes.Reverse, "相反" },
+            //{ LevelModes.MagicMonkeysOnly, "仅魔法" },
+            //{ LevelModes.DoubleHpMoabs, "双倍生命" },
+            //{ LevelModes.HalfCash, "现金减半" },
+            //{ LevelModes.AlternateBloonsRounds, "替代气球" },
+            //{ LevelModes.Impoppable, "极难" },
+            //{ LevelModes.CHIMPS, "点击" }
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            if (EasyStandard) sb.Append("简单标准 ");
+            if (MediumStandard) sb.Append("中级标准 ");
+            if (HardStandard) sb.Append("困难标准 ");
+            if (PrimaryOnly) sb.Append("仅初级 ");
+            if (MilitaryOnly) sb.Append("仅军事 ");
+            if (MagicMonkeysOnly) sb.Append("仅魔法 ");
+            if (Deflation) sb.Append("放气 ");
+            if (Apopalypse) sb.Append("天启 ");
+            if (Reverse) sb.Append("相反 ");
+            if (HalfCash) sb.Append("现金减半 ");
+            if (DoubleHpMoabs) sb.Append("双倍生命 ");
+            if (AlternateBloonsRounds) sb.Append("替代气球 ");
+            if (Impoppable) sb.Append("极难 ");
+            if (CHIMPS) sb.Append("点击 ");
+            if (sb.Length == 0) sb.Append("无");
+            return sb.ToString().Trim();
+        }
+    }
+
+}

--- a/BTD6AutoCommunity/Models/ModeDisplayItem.cs
+++ b/BTD6AutoCommunity/Models/ModeDisplayItem.cs
@@ -10,7 +10,7 @@ namespace BTD6AutoCommunity.Models
 {
     public class ModeDisplayItem
     {
-        public LevelMode Value { get; set; }
+        public LevelModes Value { get; set; }
 
         public string Name => Constants.GetTypeName(Value);
 

--- a/BTD6AutoCommunity/ScriptEngine/InstructionSystem/Instruction.cs
+++ b/BTD6AutoCommunity/ScriptEngine/InstructionSystem/Instruction.cs
@@ -63,8 +63,7 @@ namespace BTD6AutoCommunity.ScriptEngine.InstructionSystem
                 Type == ActionTypes.UpgradeMonkey || 
                 Type == ActionTypes.SwitchMonkeyTarget || 
                 Type == ActionTypes.SellMonkey || 
-                Type == ActionTypes.SetMonkeyFunction ||
-                Type == ActionTypes.AdjustMonkeyCoordinates
+                Type == ActionTypes.SetMonkeyFunction
                 )
                 return true;
             return false;

--- a/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptMetadata.cs
+++ b/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptMetadata.cs
@@ -39,7 +39,10 @@ namespace BTD6AutoCommunity.ScriptEngine.ScriptSystem
 
         public override string ToString()
         {
-            return $"[{SelectedMap}-{SelectedDifficulty}-{SelectedMode}-{SelectedHero}]";
+            return $"[{Constants.GetTypeName(SelectedMap)}-" +
+                $"{Constants.GetTypeName(SelectedDifficulty)}-" +
+                $"{Constants.GetTypeName(SelectedMode)}-" +
+                $"{Constants.GetTypeName(SelectedHero)}]";
         }
     }
 }

--- a/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptMetadata.cs
+++ b/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptMetadata.cs
@@ -15,7 +15,7 @@ namespace BTD6AutoCommunity.ScriptEngine.ScriptSystem
         public string ScriptName { get; set; }
         public Maps SelectedMap { get; set; }
         public LevelDifficulties SelectedDifficulty { get; set; }
-        public LevelMode SelectedMode { get; set; }
+        public LevelModes SelectedMode { get; set; }
         public Heroes SelectedHero { get; set; }
         public (int X, int Y) AnchorCoords { get; set; }
 
@@ -25,7 +25,7 @@ namespace BTD6AutoCommunity.ScriptEngine.ScriptSystem
             string scriptName,
             Maps selectedMap,
             LevelDifficulties selectedDifficulty,
-            LevelMode selectedMode,
+            LevelModes selectedMode,
             Heroes selectedHero,
             (int x, int y) anchorCoords)
         {
@@ -39,7 +39,7 @@ namespace BTD6AutoCommunity.ScriptEngine.ScriptSystem
 
         public override string ToString()
         {
-            return $"[{SelectedMap}-{SelectedDifficulty}-{SelectedMode}-{SelectedHero}] Anchor: ({AnchorCoords.X},{AnchorCoords.Y})";
+            return $"[{SelectedMap}-{SelectedDifficulty}-{SelectedMode}-{SelectedHero}]";
         }
     }
 }

--- a/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptModel.cs
+++ b/BTD6AutoCommunity/ScriptEngine/ScriptSystem/ScriptModel.cs
@@ -248,7 +248,7 @@ namespace BTD6AutoCommunity.ScriptEngine.ScriptSystem
     {
         public Maps SelectedMap { get; set; }
         public LevelDifficulties SelectedDifficulty { get; set; }
-        public LevelMode SelectedMode { get; set; }
+        public LevelModes SelectedMode { get; set; }
         public Heroes SelectedHero { get; set; }
         public (int, int) AnchorCoords { get; set; }
         public List<int> ObjectCount { get; set; } // 猴子的数量

--- a/BTD6AutoCommunity/Services/StrategyManager.cs
+++ b/BTD6AutoCommunity/Services/StrategyManager.cs
@@ -74,7 +74,7 @@ namespace BTD6AutoCommunity.Services
 
         private void RunCustomStrategy(UserSelection selection)
         {
-            CustomStrategy = new CustomStrategy(_settings, _logHandler, selection);
+            CustomStrategy = new CustomStrategy(_logHandler, selection);
             if (CustomStrategy.ReadyToStart)
             {
                 CustomStrategy.Start();
@@ -83,7 +83,7 @@ namespace BTD6AutoCommunity.Services
 
         private void RunCollectionStrategy()
         {
-            CollectionStrategy = new CollectionStrategy(_settings, _logHandler);
+            CollectionStrategy = new CollectionStrategy(_logHandler);
             if (CollectionStrategy.ReadyToStart)
             {
                 CollectionStrategy.Start();
@@ -92,7 +92,7 @@ namespace BTD6AutoCommunity.Services
 
         private void RunCirculationStrategy(UserSelection selection)
         {
-            CirculationStrategy = new CirculationStrategy(_settings, _logHandler, selection);
+            CirculationStrategy = new CirculationStrategy(_logHandler, selection);
             if (CirculationStrategy.ReadyToStart)
             {
                 CirculationStrategy.Start();
@@ -101,7 +101,7 @@ namespace BTD6AutoCommunity.Services
 
         private void RunRaceStrategy(UserSelection selection)
         {
-            RaceStrategy = new RaceStrategy(_settings, _logHandler, selection);
+            RaceStrategy = new RaceStrategy(_logHandler, selection);
             if (RaceStrategy.ReadyToStart)
             {
                 RaceStrategy.Start();

--- a/BTD6AutoCommunity/Strategies/BlackBorderStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/BlackBorderStrategy.cs
@@ -1,631 +1,627 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading;
-//using System.Threading.Tasks;
-//using System.Windows.Forms;
-//using static BTD6AutoCommunity.InputSimulator;
-//using static BTD6AutoCommunity.GameVisionRecognizer;
-//using static BTD6AutoCommunity.GameStateLocalization;
-//using static BTD6AutoCommunity.ScriptEditorSuite;
-//using static BTD6AutoCommunity.Constants;
-//using System.Diagnostics;
-//using System.IO;
-//using System.Runtime.Remoting.Metadata.W3cXsd2001;
-//using System.Drawing;
-//using System.CodeDom.Compiler;
-//using OpenCvSharp.ML;
-
-//namespace BTD6AutoCommunity
-//{
-//    public class BlackBorderStrategy
-//    {
-//        private readonly GameContext _context;
-//        private readonly ScriptSettings _settings;
-//        public GameContext Context => _context;
-//        private readonly GameStateMachine stateMachine;
-
-//        private readonly object _checkStateTimerLock = new object();
-//        private volatile bool _isProcessing = false;
-//        private System.Timers.Timer checkGameStateTimer;
-//        public event Action OnStopTriggered;
-
-//        private Dictionary<GameState, Action> stateHandlers;
-//        private GameState lastState = GameState.UnKnown;
-
-//        private MapTask mapTask;
-
-//        private bool IsHeroSelectionComplete;
-
-//        private int levelChallengingCount = 0;
-
-//        private ScriptEditorSuite ScriptEditorSuite;
-//        public event Action<ScriptEditorSuite> OnScriptLoaded;
-
-//        private LevelDataMonitor levelDataMonitor;
-//        private List<string> CurrentGameData; // 0: round, 1: cash, 2: life
-//        public event Action<List<string>> OnGameDataUpdated;
-
-//        private StrategyExecutor strategyExecutor;
-//        public event Action<ScriptInstructionInfo> OnCurrentStrategyCompleted;
-
-//        private System.Timers.Timer levelDataMonitorTimer;
-//        private System.Timers.Timer strategyExecutorTimer;
-//        private bool IsStrategyExecutionCompleted;
-
-//        private readonly LogHandler _logs;
-
-//        public bool ReadyToStart { get; private set; } = true;
-
-//        public BlackBorderStrategy(ScriptSettings settings, LogHandler logHandler)
-//        {
-//            _logs = logHandler;
-//            _context = new GameContext();
-//            if (_context.IsValid)
-//            {
-//                _logs.Log(_context.ToString(), LogLevel.Info);
-//                _settings = settings;
-
-//                stateMachine = new GameStateMachine(_context);
-
-//                InitializeHandlers();
-//                SetupGameStateTimer();
-
-//                currentTargetMap = (Maps)(-1);
-//            }
-//            else
-//            {
-//                ReadyToStart = false;
-//                _logs.Log("游戏窗口未找到，请确认游戏是否已启动", LogLevel.Error);
-//            }
-//        }
-
-//        private void InitializeHandlers()
-//        {
-//            stateHandlers = new Dictionary<GameState, Action>
-//            {
-//                { GameState.GameMainScreen, HandleMainScreen },
-//                { GameState.RaceResultsScreen, HandleRaceResultsScreen },
-//                { GameState.BossResultsScreen, HandleBossResultsScreen },
-//                { GameState.LevelSelectionScreen, HandleLevelSelection },
-//                { GameState.LevelSearchScreen, HandleLevelSearch },
-//                { GameState.LevelSearchedScreen, HandleLevelSearched },
-//                { GameState.LevelDifficultySelectionScreen, HandleLevelDifficultySelection },
-//                { GameState.LevelEasyModeSelectionScreen, HandleLevelEasyModeSelection },
-//                { GameState.LevelMediumModeSelectionScreen, HandleLevelMediumModeSelection },
-//                { GameState.LevelHardModeSelectionScreen, HandleLevelHardModeSelection },
-//                { GameState.HeroSelectionScreen, HandleHeroSelection },
-//                { GameState.LevelTipScreen, HandleLevelTipScreen },
-//                { GameState.LevelChallengingScreen, HandleLevelChallengingScreen },
-//                { GameState.LevelChallengingWithTipScreen, HandleLevelChallengingWithTipScreen },
-//                { GameState.LevelPassedScreen, HandleLevelPassScreen },
-//                { GameState.LevelSettlementScreen, HandleLevelSettlementScreen },
-//                { GameState.LevelFailedScreen,  HandleLevelFailedScreen },
-//                { GameState.LevelUpgradingScreen, HandleLevelUpgradingScreen },
-//                { GameState.ReturnableScreen, HandleReturnableScreen },
-//                { GameState.CollectionActivitiesAvailableScreen, HandleChestCollection },
-//                { GameState.CollectionActivitiesScreen, HandleReturnableScreen },
-//                { GameState.ThreeChestsScreen, HandleThreeChestsScreen },
-//                { GameState.TwoChestsScreen, HandleTwoChestsScreen },
-//                { GameState.InstaScreen, HandleInstaScreen },
-//                { GameState.ChestsOpenedScreen, HandleChestsOpenedScreen }
-//                //{ GameState.UnKnown, HandleReturnableScreen }
-//                // 添加更多状态处理...
-//            };
-//        }
-
-//        // 示例处理函数
-//        private void HandleMainScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 940);
-//        }
-
-//        private void HandleRaceResultsScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 800);
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//        }
-
-//        private void HandleBossResultsScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 880);
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//            Thread.Sleep(500);
-//            HandleReturnableScreen();
-//        }
-
-//        private void HandleLevelSelection()
-//        {
-//            if (!mapTask.IsWorking)
-//            {
-//                mapTask.IsWorking = true;
-//                mapTask.GetNextMap();
-//                _logs.Log($"当前目标地图：{mapTask.currentTargetMap}", LogLevel.Info);
-//                return;
-//            }
-//            MapTypes mapType = GetMapType(mapTask.currentTargetMap);
-//            Point mapTypePos = GetMapTypePos(mapType);
-//            Point mapPos = GetMapPos(_context, (int)mapTask.currentTargetMap);
-//            int mapEreaIndex = -1;
-//            int reTryCount = 0;
-//            while (mapPos.X == -1)
-//            {
-//                if (reTryCount > 8)
-//                {
-//                    _logs.Log("未找到地图位置，请确认地图是否已解锁", LogLevel.Error);
-//                    Stop();
-//                    return;
-//                }
-//                reTryCount++;
-//                MouseMoveAndLeftClick(_context, mapTypePos.X, mapTypePos.Y);
-//                Thread.Sleep(500);
-//                mapPos = GetMapPos(_context, (int)mapTask.currentTargetMap);
-//            }
-//            mapEreaIndex = GetMapEreaIndex(_context, mapPos);
-
-//            MouseMoveAndLeftClick(_context, mapPos.X, mapPos.Y);
-//        }
-
-//        private void HandleChestCollection()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 680);
-//            _logs.Log("收集宝箱可打开，开始开箱", LogLevel.Info);
-//        }
-
-//        private void HandleLevelSearch()
-//        {
-//            HandleReturnableScreen();
-//        }
-
-//        private void HandleLevelSearched()
-//        {
-//            HandleReturnableScreen();
-//        }
-
-//        private void HandleLevelDifficultySelection()
-//        {
-//            if (currentMapId < ExpertMapStartId || currentMapId > ExpertMapEndId)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("非专家级地图，无法进入收集模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            switch (mapDifficulties[currentMapId])
-//            {
-//                case 0:
-//                    MouseMoveAndLeftClick(_context, 630, 400);
-//                    break;
-//                case 1:
-//                    MouseMoveAndLeftClick(_context, 970, 400);
-//                    break;
-//                case 2:
-//                    MouseMoveAndLeftClick(_context, 1300, 400);
-//                    break;
-//            }
-//            // 加载脚本
-//            ScriptEditorSuite = LoadScript(collectionScripts[currentMapId]);
-//            ScriptEditorSuite.Compile(_settings);
-//            OnScriptLoaded?.Invoke(ScriptEditorSuite);
-//            _logs.Log($"已加载脚本：{collectionScripts[currentMapId]}", LogLevel.Info);
-//        }
-
-//        private void HandleLevelEasyModeSelection()
-//        {
-//            if (ScriptEditorSuite == null)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("脚本未加载，无法进入简单模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (ScriptEditorSuite.SelectedMode != LevelMode.Standard &&
-//                LevelModeToDifficulty[ScriptEditorSuite.SelectedMode] != LevelDifficulties.Easy)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("当前模式不是简单模式，无法进入简单模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (IsHeroSelectionComplete)
-//            {
-//                IsHeroSelectionComplete = false;
-
-//                Point point = GetLevelModePos(ScriptEditorSuite.SelectedMode);
-//                MouseMoveAndLeftClick(_context, point.X, point.Y);
-//            }
-//            else
-//            {
-//                MouseMoveAndLeftClick(_context, 100, 1000);
-//            }
-//            levelChallengingCount = 0;
-//        }
-
-//        private void HandleLevelMediumModeSelection()
-//        {
-//            if (ScriptEditorSuite == null)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("脚本未加载，无法进入中级模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (ScriptEditorSuite.SelectedMode != LevelMode.Standard &&
-//                LevelModeToDifficulty[ScriptEditorSuite.SelectedMode] != LevelDifficulties.Medium)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("当前模式不是中级模式，无法进入中级模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (IsHeroSelectionComplete)
-//            {
-//                IsHeroSelectionComplete = false;
-//                Point point = GetLevelModePos(ScriptEditorSuite.SelectedMode);
-//                MouseMoveAndLeftClick(_context, point.X, point.Y);
-//            }
-//            else
-//            {
-//                MouseMoveAndLeftClick(_context, 100, 1000);
-//            }
-//            levelChallengingCount = 0;
-//        }
-
-//        private void HandleLevelHardModeSelection()
-//        {
-//            if (ScriptEditorSuite == null)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("脚本未加载，无法进入困难模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (ScriptEditorSuite.SelectedMode != LevelMode.Standard &&
-//                LevelModeToDifficulty[ScriptEditorSuite.SelectedMode] != LevelDifficulties.Hard)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("当前模式不是困难模式，无法进入困难模式，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (IsHeroSelectionComplete)
-//            {
-//                IsHeroSelectionComplete = false;
-//                Point point = GetLevelModePos(ScriptEditorSuite.SelectedMode);
-//                MouseMoveAndLeftClick(_context, point.X, point.Y);
-//            }
-//            else
-//            {
-//                MouseMoveAndLeftClick(_context, 100, 1000);
-//            }
-//            levelChallengingCount = 0;
-//        }
-
-//        private void HandleHeroSelection()
-//        {
-//            if (ScriptEditorSuite == null)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("脚本未加载，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (IsHeroSelectionComplete || ScriptEditorSuite == null)
-//            {
-//                HandleReturnableScreen();
-//                _logs.Log("英雄选择已完成，返回", LogLevel.Error);
-//                return;
-//            }
-//            Point heroPosition = GetHeroPosition(_context, ScriptEditorSuite.SelectedHero);
-
-//            for (int i = 0; i < 5 && heroPosition.X == -1; i++)
-//            {
-//                heroPosition = GetHeroPosition(_context, ScriptEditorSuite.SelectedHero);
-//                MouseWheel(-10);
-//                Thread.Sleep(500);
-//            }
-//            if (heroPosition.X == -1)
-//            {
-//                Stop();
-//                //MessageBox.Show("未找到英雄位置！");
-//                _logs.Log("未找到英雄位置！收集结束，请卸下英雄皮肤，重新开始", LogLevel.Error);
-//                return;
-//            }
-//            //Debug.WriteLine("HeroPosition: " + heroPosition.ToString());
-//            MouseMoveAndLeftClick(_context, heroPosition.X, heroPosition.Y);
-//            Thread.Sleep(500);
-//            MouseMoveAndLeftClick(_context, 1120, 620);
-//            Thread.Sleep(500);
-//            MouseMoveAndLeftClick(_context, 80, 55);
-//            IsHeroSelectionComplete = true;
-
-//            _logs.Log($"已选择英雄：{GetTypeName(ScriptEditorSuite.SelectedHero)}", LogLevel.Info);
-//        }
-
-//        private void HandleLevelTipScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 1140, 730);
-//        }
-
-//        private void HandleLevelChallengingScreen()
-//        {
-//            levelChallengingCount++;
-//            if (ScriptEditorSuite == null)
-//            {
-//                MouseMoveAndLeftClick(_context, 1600, 40);
-//                Thread.Sleep(500);
-//                MouseMoveAndLeftClick(_context, 850, 850);
-//                _logs.Log("脚本未加载，无法进入战斗，返回", LogLevel.Error);
-//                return;
-//            }
-//            if (IsStrategyExecutionCompleted)
-//            {
-//                StopLevelTimer();
-//                return;
-//            }
-//            if (levelChallengingCount < 2)
-//            {
-//                return;
-//            }
-//            if (levelDataMonitorTimer == null)
-//            {
-//                CurrentGameData = new List<string>() { "0", "0", "0" };
-//                levelDataMonitor = new LevelDataMonitor(_context);
-//                SetupLevelDataMonitorTimer();
-//                levelDataMonitorTimer.Start();
-//                _logs.Log("已开启关卡数据识别", LogLevel.Info);
-//            }
-//            if (strategyExecutorTimer == null)
-//            {
-//                IsStrategyExecutionCompleted = false;
-//                strategyExecutor = new StrategyExecutor(_context, ScriptEditorSuite);
-//                SetupStrategyExecutorTimer();
-//                strategyExecutorTimer.Start();
-//                _logs.Log("开始执行关卡策略...", LogLevel.Info);
-//            }
-//        }
-
-//        private void HandleLevelChallengingWithTipScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 760);
-//        }
-
-//        private void HandleLevelPassScreen()
-//        {
-//            if (strategyExecutor != null && strategyExecutor.IsStartFreePlay)
-//            {
-//                MouseMoveAndLeftClick(_context, 1200, 850);
-//                strategyExecutor.StartFreePlayFinished = true;
-//                _logs.Log("自由游戏已开启，开始下一关", LogLevel.Info);
-//                return;
-//            }
-//            MouseMoveAndLeftClick(_context, 720, 850);
-//        }
-
-//        private void HandleLevelSettlementScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 910);
-//            if (strategyExecutor != null && strategyExecutor.IsStartFreePlay) return;
-//            StopLevelTimer();
-//            if (IsStrategyExecutionCompleted)
-//            {
-//                IsStrategyExecutionCompleted = false;
-//            }
-//            _logs.Log($"进入关卡结算界面，挑战成功，停止策略执行, 本关用时：{(int)(levelChallengingCount * 1.5 / 60)}分{(int)(levelChallengingCount * 1.5 % 60)}秒", LogLevel.Info);
-//        }
-
-//        private void HandleLevelUpgradingScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 980);
-//            _logs.Log("检测到升级界面，点击确认", LogLevel.Info);
-//        }
-
-//        private void HandleLevelFailedScreen()
-//        {
-//            StopLevelTimer();
-//            Point returnPos = GetFailedScreenReturnPosition(_context);
-//            MouseMoveAndLeftClick(_context, returnPos.X, returnPos.Y);
-//            _logs.Log("检测到关卡失败界面，回到主页", LogLevel.Info);
-//        }
-
-//        private void HandleReturnableScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 80, 55);
-//        }
-
-//        private void HandleThreeChestsScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 660, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 660, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 960, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 960, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 1260, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 1260, 540);
-//            Thread.Sleep(1000);
-//            _logs.Log("获得3个insta", LogLevel.Info);
-//        }
-
-//        private void HandleTwoChestsScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 810, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 810, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 1110, 540);
-//            Thread.Sleep(1000);
-//            MouseMoveAndLeftClick(_context, 1110, 540);
-//            Thread.Sleep(1000);
-//            _logs.Log("获得2个insta", LogLevel.Info);
-//        }
-
-//        private void HandleInstaScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 540);
-//        }
-
-//        private void HandleChestsOpenedScreen()
-//        {
-//            MouseMoveAndLeftClick(_context, 960, 1000);
-//        }
-
-
-//        public void Start()
-//        {
-//            _logs.Log($"开始刷黑框...", LogLevel.Info);
-
-//            mapTask = new MapTask();
-
-//            checkGameStateTimer.Start();
-//        }
-
-//        public void Stop()
-//        {
-//            checkGameStateTimer?.Stop();
-//            StopLevelTimer();
-//            lock (_checkStateTimerLock)
-//            {
-//                _isProcessing = false;
-//            }
-//            OnStopTriggered?.Invoke();
-//            _logs.Log("刷黑框模式已停止...", LogLevel.Info);
-//        }
-
-//        private void CheckGameState()
-//        {
-//            if (_isProcessing) return;
-
-//            lock (_checkStateTimerLock)
-//            {
-//                if (_isProcessing) return;
-//                _isProcessing = true;
-//            }
-//            try
-//            {
-//                var currentState = stateMachine.GetCurrentState();
-//                //Debug.WriteLine("Current State: " + GetChineseDescription(currentState));
-//                if (currentState != lastState)
-//                {
-//                    lastState = currentState;
-//                    _logs.Log($"当前状态：{GetChineseDescription(currentState)}", LogLevel.Info);
-//                }
-
-//                if (stateHandlers.TryGetValue(currentState, out Action handler))
-//                {
-//                    handler.Invoke();
-//                }
-//            }
-//            finally
-//            {
-//                lock (_checkStateTimerLock)
-//                {
-//                    _isProcessing = false;
-//                }
-//            }
-//        }
-
-//        private void ExecuteStrategy()
-//        {
-//            int currentRound = Int32.TryParse(CurrentGameData[0], out int rt) ? rt : 0;
-//            int currentCash = Int32.TryParse(CurrentGameData[1], out int ct) ? ct : 0;
-
-//            if (strategyExecutor.Finished)
-//            {
-//                if (IsStrategyExecutionCompleted == false)
-//                {
-//                    IsStrategyExecutionCompleted = true;
-//                    _logs.Log("策略执行完毕!", LogLevel.Info);
-//                }
-//                return;
-//            }
-
-//            strategyExecutor.Tick(currentRound, currentCash);
-//            //Debug.WriteLine(strategyExecutor.instructionInfo.ToString());
-//            OnCurrentStrategyCompleted?.Invoke(strategyExecutor.instructionInfo);
-//        }
-
-//        private void ReadGameData()
-//        {
-//            CurrentGameData = levelDataMonitor.GetCurrentGameData();
-//            OnGameDataUpdated?.Invoke(CurrentGameData);
-//        }
-
-
-//        private void SetupGameStateTimer()
-//        {
-//            checkGameStateTimer = new System.Timers.Timer(1500); // 1.5秒间隔
-//            checkGameStateTimer.Elapsed += (s, e) => CheckGameState();
-//            checkGameStateTimer.AutoReset = true;
-//        }
-
-//        private void SetupLevelDataMonitorTimer()
-//        {
-//            levelDataMonitorTimer = new System.Timers.Timer(_settings.DataReadInterval);
-//            levelDataMonitorTimer.Elapsed += (s, e) => ReadGameData();
-//            levelDataMonitorTimer.AutoReset = true;
-//        }
-
-//        private void SetupStrategyExecutorTimer()
-//        {
-//            strategyExecutorTimer = new System.Timers.Timer(_settings.OperationInterval);
-//            strategyExecutorTimer.Elapsed += (s, e) => ExecuteStrategy();
-//            strategyExecutorTimer.AutoReset = true;
-//        }
-
-//        private void StopLevelTimer()
-//        {
-//            if (levelDataMonitorTimer != null)
-//            {
-//                levelDataMonitorTimer.Stop();
-//                levelDataMonitorTimer.Dispose();
-//                levelDataMonitorTimer = null;
-//            }
-//            if (strategyExecutorTimer != null)
-//            {
-//                strategyExecutorTimer.Stop();
-//                strategyExecutorTimer.Dispose();
-//                strategyExecutorTimer = null;
-//            }
-//        }
-//    }
-
-//    public class MapTask
-//    {
-//        public Maps currentTargetMap { get; set; }
-
-//        public LevelDifficulties currentDifficulty { get; set; }
-
-//        public bool IsWorking { get; set; } = false;
-
-//        private Queue<Maps> mapsQueue;
-
-//        private Queue<LevelDifficulties> difficultiesQueue;
-
-//        public MapTask()
-//        {
-//            foreach (Maps item in Enum.GetValues(typeof(Maps)))
-//            {
-//                mapsQueue.Enqueue(item);
-//            }
-
-//            foreach (LevelDifficulties item in Enum.GetValues(typeof(LevelDifficulties)))
-//            {
-//                difficultiesQueue.Enqueue(item);
-//            }
-//        }
-
-//        public void GetNextMap()
-//        {
-//            currentTargetMap = mapsQueue.Dequeue();
-//        }
-//    }
-//}
+﻿using BTD6AutoCommunity.Core;
+using BTD6AutoCommunity.GameObjects;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTD6AutoCommunity.Strategies
+{
+
+    public class BlackBorderStrategyInfo
+    {
+        // 挑战失败的脚本
+        public HashSet<string> FailedScripts {  get; set; } = new HashSet<string>();
+        // 已通过的脚本
+        public HashSet<string> PassedScripts { get; set; } = new HashSet<string>();
+        // 加载失败或缺失的脚本
+        public HashSet<string> FailedScriptsToLoad {  get; set; } = new HashSet<string>();
+        // 加载成功但未挑战的脚本
+        public HashSet<string> UnChallengingScripts {  get; set; } = new HashSet<string>();
+    }
+
+    public class BlackBorderStrategy : Base.BaseStrategy
+    {
+        // 地图选择依赖
+        private bool IsMapSelectionComplete = false;
+        // 选择地图重试次数
+        private int mapReTryCount = 0;
+        private bool IsHeroSelectionComplete = false;
+        private int heroReTryCount = 0;
+        private int modeReTryCount = 0;
+        private int levelChallengingCount = 0;
+        private int returnableScreenCount = 0;
+
+        private readonly List<(LevelDifficulties, LevelModes)> scriptSequence;
+        private int scriptIndex = 0;
+        private readonly List<Maps> mapList;
+        private int mapIndex = 0;
+
+        private BlackBorderStrategyInfo strategyInfo = new BlackBorderStrategyInfo();
+
+
+        public BlackBorderStrategy(LogHandler logHandler) : base(logHandler)
+        {
+            DefaultDataReadInterval = 1000;
+            DefaultOperationInterval = 200;
+            scriptSequence = new List<(LevelDifficulties, LevelModes)>()
+            {
+                (LevelDifficulties.Easy, LevelModes.Standard),
+                (LevelDifficulties.Easy, LevelModes.PrimaryOnly),
+                (LevelDifficulties.Easy, LevelModes.Deflation),
+                (LevelDifficulties.Medium, LevelModes.Standard),
+                (LevelDifficulties.Medium, LevelModes.MilitaryOnly),
+                (LevelDifficulties.Medium, LevelModes.Apopalypse),
+                (LevelDifficulties.Medium, LevelModes.Reverse),
+                (LevelDifficulties.Hard, LevelModes.Standard),
+                (LevelDifficulties.Hard, LevelModes.MagicMonkeysOnly),
+                (LevelDifficulties.Hard, LevelModes.DoubleHpMoabs),
+                (LevelDifficulties.Hard, LevelModes.HalfCash),
+                (LevelDifficulties.Hard, LevelModes.AlternateBloonsRounds),
+                (LevelDifficulties.Hard, LevelModes.Impoppable),
+                (LevelDifficulties.Hard, LevelModes.CHIMPS)
+            };
+            mapList = new List<Maps>(Constants.MapsList);
+
+            LoadInfo();
+        }
+
+        private void LoadInfo()
+        {
+            if (!File.Exists(@"config\BlackBorderStrategyInfo.json"))
+            {
+                SaveInfo();
+                return;
+            }
+            string json = File.ReadAllText(@"config\BlackBorderStrategyInfo.json");
+            strategyInfo = JsonConvert.DeserializeObject<BlackBorderStrategyInfo>(json);
+        }
+
+        private void SaveInfo()
+        {
+            string json = JsonConvert.SerializeObject(strategyInfo, Formatting.Indented);
+            File.WriteAllText(@"config\BlackBorderStrategyInfo.json", json);
+        }
+
+        protected override void OnPostStop()
+        {
+            SaveInfo();
+            _logs.Log("黑框策略执行终止", LogLevel.Info);
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("=============================");
+            sb.AppendLine("刷黑框策略执行完毕，开始统计结果");
+            sb.AppendLine("=============================");
+            sb.AppendLine("通过的脚本：");
+            foreach (string script in strategyInfo.PassedScripts)
+            {
+                sb.AppendLine(script);
+            }
+            sb.AppendLine("=============================");
+            sb.AppendLine("未通过的脚本：");
+            foreach (string script in strategyInfo.FailedScripts)
+            {
+                sb.AppendLine(script);
+            }
+            sb.AppendLine("=============================");
+            sb.AppendLine("加载失败的脚本：");
+            foreach (string script in strategyInfo.FailedScriptsToLoad)
+            {
+                sb.AppendLine(script);
+            }
+            sb.AppendLine("=============================");
+            sb.AppendLine("未挑战的脚本：");
+            foreach (string script in strategyInfo.UnChallengingScripts)
+            {
+                sb.AppendLine(script);
+            }
+            _logs.Log(sb.ToString(), LogLevel.Info);
+        }
+
+        private bool NextScript()
+        {
+            scriptIndex++;
+            if (scriptIndex >= scriptSequence.Count)
+            {
+                mapIndex++;
+                scriptIndex = 0;
+                if (mapIndex >= mapList.Count)
+                {
+                    Stop();
+                    return false;
+                }
+            }
+            ResetCurrentScript();
+            return true;
+        }
+
+        private void NextMap()
+        {
+            mapIndex++;
+            scriptIndex = 0;
+            if (mapIndex >= mapList.Count)
+            {
+                Stop();
+                return;
+            }
+            ResetCurrentScript();
+        }
+
+        private void ResetCurrentScript()
+        {
+            scriptMetadata = null;
+            executableInstructions?.Clear();
+            executableInstructions = null;
+        }
+
+        private bool LoadScript()
+        {
+            string mapName = Constants.GetTypeName(mapList[mapIndex]);
+            string difficultyName = Constants.GetTypeName(scriptSequence[scriptIndex].Item1);
+            string modeName = Constants.GetTypeName(scriptSequence[scriptIndex].Item2);
+            string scriptName = modeName + "-黑框";
+            string scriptPath = scriptFileManager.GetScriptFullPath(mapName, difficultyName, scriptName);
+            if (!GetExecutableInstructions(scriptPath, false))
+            {
+                _logs.Log($"脚本{scriptPath}加载失败：开始下一脚本加载！", LogLevel.Warning);
+                strategyInfo.FailedScriptsToLoad.Add(scriptPath);
+                if (!NextScript()) return true;
+                return false;
+            }
+            if (strategyInfo.PassedScripts.Contains(scriptMetadata.ToString()))
+            {
+                _logs.Log($"脚本{scriptMetadata}已通过，开始下一脚本！", LogLevel.Info);
+                if (!NextScript()) return true;
+                return false;
+            }
+            _logs.Log($"脚本{scriptMetadata}加载成功！", LogLevel.Info);
+            return true;
+        }
+
+        private void InitializeRelys()
+        {
+            mapReTryCount = 0;
+            heroReTryCount = 0;
+            modeReTryCount = 0;
+            levelChallengingCount = 0;
+            returnableScreenCount = 0;
+            IsMapSelectionComplete = false;
+            IsHeroSelectionComplete = false;
+            IsStrategyExecutionCompleted = false;
+        }
+
+        protected override void InitializeStateHandlers()
+        {
+            stateHandlers = new Dictionary<GameState, Action>
+            {
+                { GameState.GameMainScreen, HandleMainScreen },
+                { GameState.RaceResultsScreen, HandleRaceResultsScreen },
+                { GameState.BossResultsScreen, HandleBossResultsScreen },
+                { GameState.LevelSelectionScreen, HandleLevelSelection },
+                { GameState.LevelSearchScreen, HandleReturnableScreen },
+                { GameState.LevelSearchedScreen, HandleReturnableScreen },
+                { GameState.LevelDifficultySelectionScreen, HandleLevelDifficultySelection },
+                { GameState.LevelEasyModeSelectionScreen, HandleLevelEasyModeSelection },
+                { GameState.LevelMediumModeSelectionScreen, HandleLevelMediumModeSelection },
+                { GameState.LevelHardModeSelectionScreen, HandleLevelHardModeSelection },
+                { GameState.HeroSelectionScreen, HandleHeroSelection },
+                { GameState.LevelTipScreen, HandleLevelTipScreen },
+                { GameState.LevelChallengingScreen, HandleLevelChallengingScreen },
+                { GameState.LevelChallengingWithTipScreen, HandleLevelChallengingWithTipScreen },
+                { GameState.LevelSettingScreen, HandleLevelSettingScreen },
+                { GameState.LevelPassedScreen, HandleLevelPassScreen },
+                { GameState.LevelSettlementScreen, HandleLevelSettlementScreen },
+                { GameState.LevelFailedScreen,  HandleLevelFailedScreen },
+                { GameState.LevelUpgradingScreen, HandleLevelUpgradingScreen },
+                { GameState.ReturnableScreen, HandleReturnableScreen },
+                { GameState.CollectionActivitiesAvailableScreen, HandleChestCollection },
+                { GameState.CollectionActivitiesScreen, HandleReturnableScreen },
+                { GameState.ThreeChestsScreen, HandleThreeChestsScreen },
+                { GameState.TwoChestsScreen, HandleTwoChestsScreen },
+                { GameState.InstaScreen, HandleInstaScreen },
+                { GameState.ChestsOpenedScreen, HandleChestsOpenedScreen }
+                //{ GameState.UnKnown, HandleReturnableScreen }
+
+                // 添加更多状态处理...
+            };
+        }
+
+        private void HandleMainScreen()
+        {
+            InitializeRelys();
+            while (!LoadScript()) { }
+            EchoScript();
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 940);
+        }
+
+        private void HandleRaceResultsScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 800);
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+        }
+
+        private void HandleBossResultsScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 880);
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+            Thread.Sleep(500);
+            HandleReturnableScreen();
+        }
+
+        private void HandleLevelSelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，无法选择难度，返回", LogLevel.Warning);
+                return;
+            }
+            MapTypes mapType = Constants.GetMapType(scriptMetadata.SelectedMap);
+            Point mapTypePos = Constants.GetMapTypePos(mapType);
+            Point mapPos = GameVisionRecognizer.GetMapPos(_context, (int)scriptMetadata.SelectedMap);
+            if (mapPos.X == -1)
+            {
+                if (mapReTryCount > 8)
+                {
+                    mapReTryCount = 0;
+                    NextMap();
+                    strategyInfo.UnChallengingScripts.Add(scriptMetadata.ToString());
+                    _logs.Log($"未找到地图位置, 开始尝试下一张地图：{Constants.GetTypeName(mapList[mapIndex])}！", LogLevel.Warning);
+                    return;
+                }
+                mapReTryCount++;
+                InputSimulator.MouseMoveAndLeftClick(_context, mapTypePos.X, mapTypePos.Y);
+                return;
+            }
+            InputSimulator.MouseMoveAndLeftClick(_context, mapPos.X, mapPos.Y);
+            IsMapSelectionComplete = true;
+            _logs.Log($"已选择地图：{Constants.GetTypeName(scriptMetadata.SelectedMap)}", LogLevel.Info);
+        }
+
+        private void HandleLevelDifficultySelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，返回", LogLevel.Warning);
+                return;
+            }
+            if (!IsMapSelectionComplete)
+            {
+                HandleReturnableScreen();
+                _logs.Log("地图选择未完成，无法选择难度，返回", LogLevel.Warning);
+                return;
+            }
+            switch (scriptMetadata.SelectedDifficulty)
+            {
+                case LevelDifficulties.Easy:
+                    InputSimulator.MouseMoveAndLeftClick(_context, 630, 400);
+                    break;
+                case LevelDifficulties.Medium:
+                    InputSimulator.MouseMoveAndLeftClick(_context, 970, 400);
+                    break;
+                case LevelDifficulties.Hard:
+                    InputSimulator.MouseMoveAndLeftClick(_context, 1300, 400);
+                    break;
+            }
+        }
+
+        private void HandleLevelEasyModeSelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，无法进入简单模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (!IsMapSelectionComplete)
+            {
+                HandleReturnableScreen();
+                _logs.Log("地图选择未完成，无法进入简单模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
+                Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Easy)
+            {
+                HandleReturnableScreen();
+                _logs.Log("当前模式不是简单模式，无法进入简单模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (IsHeroSelectionComplete)
+            {
+                IsHeroSelectionComplete = false;
+
+                Point point = Constants.GetLevelModePos(scriptMetadata.SelectedMode);
+                InputSimulator.MouseMoveAndLeftClick(_context, point.X, point.Y);
+            }
+            else
+            {
+                if (modeReTryCount > 7)
+                {
+                    modeReTryCount = 0;
+                    strategyInfo.UnChallengingScripts.Add(scriptMetadata.ToString());
+                    _logs.Log($"未找到简单模式：{Constants.GetTypeName(scriptMetadata.SelectedMode)}位置，请确认是否已解锁，开始尝试下一脚本！", LogLevel.Warning);
+                    NextScript();
+                    return;
+                }
+                modeReTryCount++;
+                InputSimulator.MouseMoveAndLeftClick(_context, 100, 1000);
+            }
+        }
+
+        private void HandleLevelMediumModeSelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，无法进入中级模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (!IsMapSelectionComplete)
+            {
+                HandleReturnableScreen();
+                _logs.Log("地图选择未完成，无法进入中级模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
+                Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Medium)
+            {
+                HandleReturnableScreen();
+                _logs.Log("当前模式不是中级模式，无法进入中级模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (IsHeroSelectionComplete)
+            {
+                IsHeroSelectionComplete = false;
+                Point point = Constants.GetLevelModePos(scriptMetadata.SelectedMode);
+                InputSimulator.MouseMoveAndLeftClick(_context, point.X, point.Y);
+            }
+            else
+            {
+                if (modeReTryCount > 7)
+                {
+                    modeReTryCount = 0;
+                    strategyInfo.UnChallengingScripts.Add(scriptMetadata.ToString());
+                    _logs.Log($"未找到中级模式：{Constants.GetTypeName(scriptMetadata.SelectedMode)}位置，请确认是否已解锁，开始尝试下一脚本！", LogLevel.Warning);
+                    NextScript();
+                    return;
+                }
+                modeReTryCount++;
+                InputSimulator.MouseMoveAndLeftClick(_context, 100, 1000);
+            }
+        }
+
+        private void HandleLevelHardModeSelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，无法进入困难模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (!IsMapSelectionComplete)
+            {
+                HandleReturnableScreen();
+                _logs.Log("地图选择未完成，无法进入困难模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
+                Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Hard)
+            {
+                HandleReturnableScreen();
+                _logs.Log("当前模式不是困难模式，无法进入困难模式，返回", LogLevel.Warning);
+                return;
+            }
+            if (IsHeroSelectionComplete)
+            {
+                IsHeroSelectionComplete = false;
+                Point point = Constants.GetLevelModePos(scriptMetadata.SelectedMode);
+                InputSimulator.MouseMoveAndLeftClick(_context, point.X, point.Y);
+            }
+            else
+            {
+                if (modeReTryCount > 7)
+                {
+                    modeReTryCount = 0;
+                    strategyInfo.UnChallengingScripts.Add(scriptMetadata.ToString());
+                    _logs.Log($"未找到困难模式：{Constants.GetTypeName(scriptMetadata.SelectedMode)}位置，请确认是否已解锁，开始尝试下一脚本！", LogLevel.Warning);
+                    NextScript();
+                    return;
+                }
+                modeReTryCount++;
+                InputSimulator.MouseMoveAndLeftClick(_context, 100, 1000);
+            }
+        }
+
+        private void HandleHeroSelection()
+        {
+            if (executableInstructions == null || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("脚本未加载，无法选择英雄，返回", LogLevel.Warning);
+                return;
+            }
+            if (IsHeroSelectionComplete || scriptMetadata == null)
+            {
+                HandleReturnableScreen();
+                _logs.Log("英雄选择已完成，返回", LogLevel.Warning);
+                return;
+            }
+            Point heroPosition = GameVisionRecognizer.GetHeroPosition(_context, scriptMetadata.SelectedHero);
+            if (heroPosition.X == -1)
+            {
+                
+                if (heroReTryCount > 7)
+                {
+                    heroReTryCount = 0;
+                    NextScript();
+                    strategyInfo.UnChallengingScripts.Add(scriptMetadata.ToString());
+                    _logs.Log("未找到英雄位置，请确认英雄是否已解锁，开始尝试下一脚本！", LogLevel.Warning);
+                    return;
+                }
+                heroReTryCount++;
+                InputSimulator.MouseWheel(-10);
+                return;
+            }
+            InputSimulator.MouseMoveAndLeftClick(_context, heroPosition.X, heroPosition.Y);
+            Thread.Sleep(500);
+            InputSimulator.MouseMoveAndLeftClick(_context, 1120, 620);
+            Thread.Sleep(500);
+            InputSimulator.MouseMoveAndLeftClick(_context, 80, 55);
+            IsHeroSelectionComplete = true;
+
+            _logs.Log($"已选择英雄：{Constants.GetTypeName(scriptMetadata.SelectedHero)}", LogLevel.Info);
+        }
+
+        private void HandleLevelTipScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 1140, 730);
+        }
+
+        private void HandleLevelChallengingScreen()
+        {
+            levelChallengingCount++;
+            if (scriptMetadata == null)
+            {
+                InputSimulator.MouseMoveAndLeftClick(_context, 1600, 40);
+                Thread.Sleep(500);
+                InputSimulator.MouseMoveAndLeftClick(_context, 850, 850);
+                _logs.Log("脚本未加载，无法进入战斗，返回", LogLevel.Warning);
+                return;
+            }
+            if (!IsMapSelectionComplete)
+            {
+                InputSimulator.MouseMoveAndLeftClick(_context, 1600, 40);
+                Thread.Sleep(500);
+                InputSimulator.MouseMoveAndLeftClick(_context, 850, 850);
+                _logs.Log("地图选择未完成，无法进入战斗，返回", LogLevel.Warning);
+                return;
+            }
+            if (levelChallengingCount < 3)
+            {
+                return;
+            }
+            if (IsStrategyExecutionCompleted)
+            {
+                StopLevelTimer();
+                return;
+            }
+            StartLevelTimer(0, _settings.EnableRecommendInterval);
+        }
+
+        private void HandleLevelChallengingWithTipScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 760);
+        }
+
+        private void HandleLevelSettingScreen()
+        {
+        }
+
+        private void HandleLevelPassScreen()
+        {
+            Point returnPos = GameVisionRecognizer.GetSettlementScreenReturnPosition(_context);
+            InputSimulator.MouseMoveAndLeftClick(_context, returnPos.X, returnPos.Y);
+        }
+
+        private void HandleLevelSettlementScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 910);
+            StopLevelTimer();
+            if (IsStrategyExecutionCompleted)
+            {
+                IsStrategyExecutionCompleted = false;
+            }
+            strategyInfo.PassedScripts.Add(scriptMetadata.ToString());
+            NextScript();
+            _logs.Log($"进入关卡结算界面，挑战成功，停止策略执行, 本关用时：{(int)(levelChallengingCount * 1.5 / 60)}分{(int)(levelChallengingCount * 1.5 % 60)}秒", LogLevel.Info);
+        }
+
+        private void HandleLevelFailedScreen()
+        {
+            StopLevelTimer();
+            Point returnPos = GameVisionRecognizer.GetFailedScreenReturnPosition(_context);
+            InputSimulator.MouseMoveAndLeftClick(_context, returnPos.X, returnPos.Y);
+            strategyInfo.FailedScripts.Add(scriptMetadata.ToString());
+            _logs.Log($"检测到关卡失败界面，失败脚本：{scriptMetadata.ScriptName}。回到主页，开始下一脚本！", LogLevel.Warning);
+            NextScript();
+        }
+
+        private void HandleLevelUpgradingScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 980);
+            _logs.Log("检测到升级界面，点击确认", LogLevel.Info);
+        }
+
+        private void HandleReturnableScreen()
+        {
+            returnableScreenCount++;
+            if (returnableScreenCount < 2) return;
+            InputSimulator.MouseMoveAndLeftClick(_context, 80, 55);
+            returnableScreenCount = 0;
+        }
+
+        private void HandleChestCollection()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 680);
+            _logs.Log("收集宝箱可打开，开始开箱", LogLevel.Info);
+        }
+
+        private void HandleThreeChestsScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 660, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 660, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 1260, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 1260, 540);
+            Thread.Sleep(1000);
+            _logs.Log("获得3个insta", LogLevel.Info);
+        }
+
+        private void HandleTwoChestsScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 810, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 810, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 1110, 540);
+            Thread.Sleep(1000);
+            InputSimulator.MouseMoveAndLeftClick(_context, 1110, 540);
+            Thread.Sleep(1000);
+            _logs.Log("获得2个insta", LogLevel.Info);
+        }
+
+        private void HandleInstaScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 540);
+        }
+
+        private void HandleChestsOpenedScreen()
+        {
+            InputSimulator.MouseMoveAndLeftClick(_context, 960, 1000);
+        }
+
+    }
+}

--- a/BTD6AutoCommunity/Strategies/CirculationStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/CirculationStrategy.cs
@@ -25,8 +25,8 @@ namespace BTD6AutoCommunity.Strategies
         private int levelChallengingCount = 0;
         private int returnableScreenCount = 0;
 
-        public CirculationStrategy(ScriptSettings settings, LogHandler logHandler, UserSelection userSelection)
-            : base(settings, logHandler)
+        public CirculationStrategy(LogHandler logHandler, UserSelection userSelection)
+            : base(logHandler)
         {
             DefaultDataReadInterval = 1000;
             DefaultOperationInterval = 200;
@@ -196,7 +196,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("地图选择未完成，无法进入简单模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard && 
+            if (scriptMetadata.SelectedMode != LevelModes.Standard && 
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Easy)
             {
                 HandleReturnableScreen();
@@ -232,7 +232,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("地图选择未完成，无法进入中级模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard &&
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Medium)
             {
                 HandleReturnableScreen();
@@ -267,7 +267,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("地图选择未完成，无法进入困难模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard &&
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Hard)
             {
                 HandleReturnableScreen();
@@ -313,8 +313,7 @@ namespace BTD6AutoCommunity.Strategies
             if (heroPosition.X == -1)
             {
                 Stop();
-                //MessageBox.Show("未找到英雄位置！");
-                _logs.Log("未找到英雄位置！收集结束，请卸下英雄皮肤，重新开始", LogLevel.Error);
+                _logs.Log("未找到英雄位置！请卸下英雄皮肤，重新开始", LogLevel.Error);
                 return;
             }
             InputSimulator.MouseMoveAndLeftClick(_context, heroPosition.X, heroPosition.Y);

--- a/BTD6AutoCommunity/Strategies/CollectionStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/CollectionStrategy.cs
@@ -43,8 +43,8 @@ namespace BTD6AutoCommunity.Strategies
 
         private int returnableScreenCount = 0;
 
-        public CollectionStrategy(ScriptSettings settings, LogHandler logHandler)
-            : base(settings, logHandler)
+        public CollectionStrategy(LogHandler logHandler)
+            : base(logHandler)
         {
             DefaultDataReadInterval = 1000;
             DefaultOperationInterval = 200;
@@ -226,7 +226,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("脚本未加载，无法进入简单模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard &&
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Easy)
             {
                 HandleReturnableScreen();
@@ -255,7 +255,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("脚本未加载，无法进入中级模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard &&
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Medium)
             {
                 HandleReturnableScreen();
@@ -283,7 +283,7 @@ namespace BTD6AutoCommunity.Strategies
                 _logs.Log("脚本未加载，无法进入困难模式，返回", LogLevel.Warning);
                 return;
             }
-            if (scriptMetadata.SelectedMode != LevelMode.Standard &&
+            if (scriptMetadata.SelectedMode != LevelModes.Standard &&
                 Constants.LevelModeToDifficulty[scriptMetadata.SelectedMode] != LevelDifficulties.Hard)
             {
                 HandleReturnableScreen();
@@ -425,15 +425,15 @@ namespace BTD6AutoCommunity.Strategies
         private void HandleThreeChestsScreen()
         {
             InputSimulator.MouseMoveAndLeftClick(_context, 660, 540);
-            Thread.Sleep(1000);
+            Thread.Sleep(2000);
             InputSimulator.MouseMoveAndLeftClick(_context, 660, 540);
             Thread.Sleep(1000);
             InputSimulator.MouseMoveAndLeftClick(_context, 960, 540);
-            Thread.Sleep(1000);
+            Thread.Sleep(2000);
             InputSimulator.MouseMoveAndLeftClick(_context, 960, 540);
             Thread.Sleep(1000);
             InputSimulator.MouseMoveAndLeftClick(_context, 1260, 540);
-            Thread.Sleep(1000);
+            Thread.Sleep(2000);
             InputSimulator.MouseMoveAndLeftClick(_context, 1260, 540);
             Thread.Sleep(1000);
             _logs.Log("获得3个insta", LogLevel.Info);

--- a/BTD6AutoCommunity/Strategies/CollectionStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/CollectionStrategy.cs
@@ -28,9 +28,9 @@ namespace BTD6AutoCommunity.Strategies
     public class CollectionStrategy : Base.BaseStrategy
     {
         // 收集设置常量
-        private const int CollectMapCount = 12;          // 每次运行收集地图数量
+        private const int CollectMapCount = 13;          // 每次运行收集地图数量
         private const int ExpertMapStartId = 90;        // 专家级地图起始ID
-        private const int ExpertMapEndId = 101;           // 专家级地图终止ID
+        private const int ExpertMapEndId = 102;           // 专家级地图终止ID
 
 
         private Dictionary<int, string> collectionScripts; // mapId -> 脚本路径

--- a/BTD6AutoCommunity/Strategies/CustomStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/CustomStrategy.cs
@@ -39,8 +39,8 @@ namespace BTD6AutoCommunity.Strategies
         protected override void OnPreStart()
         {
             _logs.Log($"开始自定义策略...", LogLevel.Info);
-            checkGameStateTimer?.Dispose();
-            checkGameStateTimer = null;
+            screenShotCaptureTimer?.Dispose();
+            screenShotCaptureTimer = null;
         }
 
         protected override void OnPostStart()

--- a/BTD6AutoCommunity/Strategies/CustomStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/CustomStrategy.cs
@@ -18,11 +18,11 @@ namespace BTD6AutoCommunity.Strategies
     {
         protected int startIndex = 0;
 
-        public CustomStrategy(ScriptSettings settings, LogHandler logHandler, UserSelection userSelection)
-            : base(settings, logHandler)
+        public CustomStrategy(LogHandler logHandler, UserSelection userSelection)
+            : base(logHandler)
         {
-            DefaultDataReadInterval = settings.DataReadInterval;
-            DefaultOperationInterval = settings.OperationInterval;
+            DefaultDataReadInterval = _settings.DataReadInterval;
+            DefaultOperationInterval = _settings.OperationInterval;
             startIndex = userSelection.selectedIndex;
             InitializeStateHandlers();
             GetExecutableInstructions(userSelection);

--- a/BTD6AutoCommunity/Strategies/RaceStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/RaceStrategy.cs
@@ -19,8 +19,8 @@ namespace BTD6AutoCommunity.Strategies
         private int levelChallengingCount = 0;
 
 
-        public RaceStrategy(ScriptSettings settings, LogHandler logHandler, UserSelection userSelection)
-            : base(settings, logHandler)
+        public RaceStrategy(LogHandler logHandler, UserSelection userSelection)
+            : base(logHandler)
         {
             InitializeStateHandlers();
             GetExecutableInstructions(userSelection);

--- a/BTD6AutoCommunity/UI/Main/Form1.Designer.cs
+++ b/BTD6AutoCommunity/UI/Main/Form1.Designer.cs
@@ -1520,7 +1520,7 @@
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel19.Size = new System.Drawing.Size(557, 202);
+            this.tableLayoutPanel19.Size = new System.Drawing.Size(558, 202);
             this.tableLayoutPanel19.TabIndex = 1;
             // 
             // label10
@@ -1641,7 +1641,7 @@
             this.EnableFastPathCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EnableFastPathCB.Location = new System.Drawing.Point(263, 163);
             this.EnableFastPathCB.Name = "EnableFastPathCB";
-            this.EnableFastPathCB.Size = new System.Drawing.Size(291, 36);
+            this.EnableFastPathCB.Size = new System.Drawing.Size(292, 36);
             this.EnableFastPathCB.TabIndex = 7;
             this.EnableFastPathCB.Text = "快速路径";
             this.EnableFastPathCB.UseVisualStyleBackColor = true;
@@ -1845,7 +1845,7 @@
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel17.Size = new System.Drawing.Size(557, 1374);
+            this.tableLayoutPanel17.Size = new System.Drawing.Size(558, 1374);
             this.tableLayoutPanel17.TabIndex = 3;
             // 
             // SpikeFactoryHotkeyBT
@@ -1853,7 +1853,7 @@
             this.SpikeFactoryHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SpikeFactoryHotkeyBT.Location = new System.Drawing.Point(128, 443);
             this.SpikeFactoryHotkeyBT.Name = "SpikeFactoryHotkeyBT";
-            this.SpikeFactoryHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.SpikeFactoryHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SpikeFactoryHotkeyBT.TabIndex = 41;
             this.SpikeFactoryHotkeyBT.Tag = "31";
             this.SpikeFactoryHotkeyBT.Text = "button42";
@@ -1863,7 +1863,7 @@
             // BananaFarmHotkeyBT
             // 
             this.BananaFarmHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BananaFarmHotkeyBT.Location = new System.Drawing.Point(406, 403);
+            this.BananaFarmHotkeyBT.Location = new System.Drawing.Point(407, 403);
             this.BananaFarmHotkeyBT.Name = "BananaFarmHotkeyBT";
             this.BananaFarmHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.BananaFarmHotkeyBT.TabIndex = 39;
@@ -1877,7 +1877,7 @@
             this.MerMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MerMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 403);
             this.MerMonkeyHotkeyBT.Name = "MerMonkeyHotkeyBT";
-            this.MerMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.MerMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MerMonkeyHotkeyBT.TabIndex = 37;
             this.MerMonkeyHotkeyBT.Tag = "25";
             this.MerMonkeyHotkeyBT.Text = "button38";
@@ -1887,7 +1887,7 @@
             // DruidHotkeyBT
             // 
             this.DruidHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DruidHotkeyBT.Location = new System.Drawing.Point(406, 363);
+            this.DruidHotkeyBT.Location = new System.Drawing.Point(407, 363);
             this.DruidHotkeyBT.Name = "DruidHotkeyBT";
             this.DruidHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.DruidHotkeyBT.TabIndex = 35;
@@ -1901,7 +1901,7 @@
             this.AlchemistHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AlchemistHotkeyBT.Location = new System.Drawing.Point(128, 363);
             this.AlchemistHotkeyBT.Name = "AlchemistHotkeyBT";
-            this.AlchemistHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.AlchemistHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.AlchemistHotkeyBT.TabIndex = 33;
             this.AlchemistHotkeyBT.Tag = "23";
             this.AlchemistHotkeyBT.Text = "button34";
@@ -1911,7 +1911,7 @@
             // NinjaMonkeyHotkeyBT
             // 
             this.NinjaMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.NinjaMonkeyHotkeyBT.Location = new System.Drawing.Point(406, 323);
+            this.NinjaMonkeyHotkeyBT.Location = new System.Drawing.Point(407, 323);
             this.NinjaMonkeyHotkeyBT.Name = "NinjaMonkeyHotkeyBT";
             this.NinjaMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.NinjaMonkeyHotkeyBT.TabIndex = 31;
@@ -1925,7 +1925,7 @@
             this.SuperMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SuperMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 323);
             this.SuperMonkeyHotkeyBT.Name = "SuperMonkeyHotkeyBT";
-            this.SuperMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.SuperMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SuperMonkeyHotkeyBT.TabIndex = 29;
             this.SuperMonkeyHotkeyBT.Tag = "21";
             this.SuperMonkeyHotkeyBT.Text = "button30";
@@ -1935,7 +1935,7 @@
             // WizardMonkeyHotkeyBT
             // 
             this.WizardMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.WizardMonkeyHotkeyBT.Location = new System.Drawing.Point(406, 283);
+            this.WizardMonkeyHotkeyBT.Location = new System.Drawing.Point(407, 283);
             this.WizardMonkeyHotkeyBT.Name = "WizardMonkeyHotkeyBT";
             this.WizardMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.WizardMonkeyHotkeyBT.TabIndex = 27;
@@ -1949,7 +1949,7 @@
             this.DartlingGunnerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DartlingGunnerHotkeyBT.Location = new System.Drawing.Point(128, 283);
             this.DartlingGunnerHotkeyBT.Name = "DartlingGunnerHotkeyBT";
-            this.DartlingGunnerHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.DartlingGunnerHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.DartlingGunnerHotkeyBT.TabIndex = 25;
             this.DartlingGunnerHotkeyBT.Tag = "16";
             this.DartlingGunnerHotkeyBT.Text = "button26";
@@ -1959,7 +1959,7 @@
             // MortarMonkeyHotkeyBT
             // 
             this.MortarMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MortarMonkeyHotkeyBT.Location = new System.Drawing.Point(406, 243);
+            this.MortarMonkeyHotkeyBT.Location = new System.Drawing.Point(407, 243);
             this.MortarMonkeyHotkeyBT.Name = "MortarMonkeyHotkeyBT";
             this.MortarMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MortarMonkeyHotkeyBT.TabIndex = 23;
@@ -1973,7 +1973,7 @@
             this.HeliPilotHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeliPilotHotkeyBT.Location = new System.Drawing.Point(128, 243);
             this.HeliPilotHotkeyBT.Name = "HeliPilotHotkeyBT";
-            this.HeliPilotHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeliPilotHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeliPilotHotkeyBT.TabIndex = 21;
             this.HeliPilotHotkeyBT.Tag = "14";
             this.HeliPilotHotkeyBT.Text = "button22";
@@ -1983,7 +1983,7 @@
             // MonkeyAceHotkeyBT
             // 
             this.MonkeyAceHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeyAceHotkeyBT.Location = new System.Drawing.Point(406, 203);
+            this.MonkeyAceHotkeyBT.Location = new System.Drawing.Point(407, 203);
             this.MonkeyAceHotkeyBT.Name = "MonkeyAceHotkeyBT";
             this.MonkeyAceHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MonkeyAceHotkeyBT.TabIndex = 19;
@@ -1997,7 +1997,7 @@
             this.MonkeyBuccaneerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MonkeyBuccaneerHotkeyBT.Location = new System.Drawing.Point(128, 203);
             this.MonkeyBuccaneerHotkeyBT.Name = "MonkeyBuccaneerHotkeyBT";
-            this.MonkeyBuccaneerHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.MonkeyBuccaneerHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MonkeyBuccaneerHotkeyBT.TabIndex = 17;
             this.MonkeyBuccaneerHotkeyBT.Tag = "12";
             this.MonkeyBuccaneerHotkeyBT.Text = "button18";
@@ -2007,7 +2007,7 @@
             // MonkeySubHotkeyBT
             // 
             this.MonkeySubHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeySubHotkeyBT.Location = new System.Drawing.Point(406, 163);
+            this.MonkeySubHotkeyBT.Location = new System.Drawing.Point(407, 163);
             this.MonkeySubHotkeyBT.Name = "MonkeySubHotkeyBT";
             this.MonkeySubHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MonkeySubHotkeyBT.TabIndex = 15;
@@ -2021,7 +2021,7 @@
             this.SniperMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SniperMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 163);
             this.SniperMonkeyHotkeyBT.Name = "SniperMonkeyHotkeyBT";
-            this.SniperMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.SniperMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SniperMonkeyHotkeyBT.TabIndex = 13;
             this.SniperMonkeyHotkeyBT.Tag = "10";
             this.SniperMonkeyHotkeyBT.Text = "button14";
@@ -2031,7 +2031,7 @@
             // GlueGunnerHotkeyBT
             // 
             this.GlueGunnerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GlueGunnerHotkeyBT.Location = new System.Drawing.Point(406, 123);
+            this.GlueGunnerHotkeyBT.Location = new System.Drawing.Point(407, 123);
             this.GlueGunnerHotkeyBT.Name = "GlueGunnerHotkeyBT";
             this.GlueGunnerHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.GlueGunnerHotkeyBT.TabIndex = 11;
@@ -2045,7 +2045,7 @@
             this.IceMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.IceMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 123);
             this.IceMonkeyHotkeyBT.Name = "IceMonkeyHotkeyBT";
-            this.IceMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.IceMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.IceMonkeyHotkeyBT.TabIndex = 9;
             this.IceMonkeyHotkeyBT.Tag = "4";
             this.IceMonkeyHotkeyBT.Text = "button10";
@@ -2055,7 +2055,7 @@
             // TackShooterHotkeyBT
             // 
             this.TackShooterHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.TackShooterHotkeyBT.Location = new System.Drawing.Point(406, 83);
+            this.TackShooterHotkeyBT.Location = new System.Drawing.Point(407, 83);
             this.TackShooterHotkeyBT.Name = "TackShooterHotkeyBT";
             this.TackShooterHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.TackShooterHotkeyBT.TabIndex = 7;
@@ -2069,7 +2069,7 @@
             this.BombShooterHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.BombShooterHotkeyBT.Location = new System.Drawing.Point(128, 83);
             this.BombShooterHotkeyBT.Name = "BombShooterHotkeyBT";
-            this.BombShooterHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.BombShooterHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.BombShooterHotkeyBT.TabIndex = 5;
             this.BombShooterHotkeyBT.Tag = "2";
             this.BombShooterHotkeyBT.Text = "button6";
@@ -2081,7 +2081,7 @@
             this.DartMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DartMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 43);
             this.DartMonkeyHotkeyBT.Name = "DartMonkeyHotkeyBT";
-            this.DartMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.DartMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.DartMonkeyHotkeyBT.TabIndex = 0;
             this.DartMonkeyHotkeyBT.Tag = "";
             this.DartMonkeyHotkeyBT.Text = "Hot1";
@@ -2091,7 +2091,7 @@
             // BoomerangMonkeyHotkeyBT
             // 
             this.BoomerangMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BoomerangMonkeyHotkeyBT.Location = new System.Drawing.Point(406, 43);
+            this.BoomerangMonkeyHotkeyBT.Location = new System.Drawing.Point(407, 43);
             this.BoomerangMonkeyHotkeyBT.Name = "BoomerangMonkeyHotkeyBT";
             this.BoomerangMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.BoomerangMonkeyHotkeyBT.TabIndex = 1;
@@ -2103,7 +2103,7 @@
             // MonkeyVillageHotkeyBT
             // 
             this.MonkeyVillageHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeyVillageHotkeyBT.Location = new System.Drawing.Point(406, 443);
+            this.MonkeyVillageHotkeyBT.Location = new System.Drawing.Point(407, 443);
             this.MonkeyVillageHotkeyBT.Name = "MonkeyVillageHotkeyBT";
             this.MonkeyVillageHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.MonkeyVillageHotkeyBT.TabIndex = 42;
@@ -2117,7 +2117,7 @@
             this.EngineerMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EngineerMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 483);
             this.EngineerMonkeyHotkeyBT.Name = "EngineerMonkeyHotkeyBT";
-            this.EngineerMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.EngineerMonkeyHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.EngineerMonkeyHotkeyBT.TabIndex = 43;
             this.EngineerMonkeyHotkeyBT.Tag = "33";
             this.EngineerMonkeyHotkeyBT.Text = "button4";
@@ -2127,7 +2127,7 @@
             // BeastHandlerHotkeyBT
             // 
             this.BeastHandlerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BeastHandlerHotkeyBT.Location = new System.Drawing.Point(406, 483);
+            this.BeastHandlerHotkeyBT.Location = new System.Drawing.Point(407, 483);
             this.BeastHandlerHotkeyBT.Name = "BeastHandlerHotkeyBT";
             this.BeastHandlerHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.BeastHandlerHotkeyBT.TabIndex = 44;
@@ -2151,7 +2151,7 @@
             // 
             this.label16.AutoSize = true;
             this.label16.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label16.Location = new System.Drawing.Point(281, 40);
+            this.label16.Location = new System.Drawing.Point(282, 40);
             this.label16.Name = "label16";
             this.label16.Size = new System.Drawing.Size(119, 40);
             this.label16.TabIndex = 48;
@@ -2173,7 +2173,7 @@
             // 
             this.label18.AutoSize = true;
             this.label18.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label18.Location = new System.Drawing.Point(281, 80);
+            this.label18.Location = new System.Drawing.Point(282, 80);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(119, 40);
             this.label18.TabIndex = 50;
@@ -2184,7 +2184,7 @@
             // 
             this.label19.AutoSize = true;
             this.label19.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label19.Location = new System.Drawing.Point(281, 120);
+            this.label19.Location = new System.Drawing.Point(282, 120);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(119, 40);
             this.label19.TabIndex = 51;
@@ -2206,7 +2206,7 @@
             // 
             this.label21.AutoSize = true;
             this.label21.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label21.Location = new System.Drawing.Point(281, 160);
+            this.label21.Location = new System.Drawing.Point(282, 160);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(119, 40);
             this.label21.TabIndex = 53;
@@ -2228,7 +2228,7 @@
             // 
             this.label23.AutoSize = true;
             this.label23.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label23.Location = new System.Drawing.Point(281, 200);
+            this.label23.Location = new System.Drawing.Point(282, 200);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(119, 40);
             this.label23.TabIndex = 55;
@@ -2250,7 +2250,7 @@
             // 
             this.label25.AutoSize = true;
             this.label25.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label25.Location = new System.Drawing.Point(281, 240);
+            this.label25.Location = new System.Drawing.Point(282, 240);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(119, 40);
             this.label25.TabIndex = 57;
@@ -2272,7 +2272,7 @@
             // 
             this.label27.AutoSize = true;
             this.label27.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label27.Location = new System.Drawing.Point(281, 280);
+            this.label27.Location = new System.Drawing.Point(282, 280);
             this.label27.Name = "label27";
             this.label27.Size = new System.Drawing.Size(119, 40);
             this.label27.TabIndex = 59;
@@ -2294,7 +2294,7 @@
             // 
             this.label29.AutoSize = true;
             this.label29.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label29.Location = new System.Drawing.Point(281, 320);
+            this.label29.Location = new System.Drawing.Point(282, 320);
             this.label29.Name = "label29";
             this.label29.Size = new System.Drawing.Size(119, 40);
             this.label29.TabIndex = 61;
@@ -2327,7 +2327,7 @@
             // 
             this.label32.AutoSize = true;
             this.label32.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label32.Location = new System.Drawing.Point(281, 360);
+            this.label32.Location = new System.Drawing.Point(282, 360);
             this.label32.Name = "label32";
             this.label32.Size = new System.Drawing.Size(119, 40);
             this.label32.TabIndex = 64;
@@ -2349,7 +2349,7 @@
             // 
             this.label34.AutoSize = true;
             this.label34.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label34.Location = new System.Drawing.Point(281, 400);
+            this.label34.Location = new System.Drawing.Point(282, 400);
             this.label34.Name = "label34";
             this.label34.Size = new System.Drawing.Size(119, 40);
             this.label34.TabIndex = 66;
@@ -2371,7 +2371,7 @@
             // 
             this.label36.AutoSize = true;
             this.label36.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label36.Location = new System.Drawing.Point(281, 440);
+            this.label36.Location = new System.Drawing.Point(282, 440);
             this.label36.Name = "label36";
             this.label36.Size = new System.Drawing.Size(119, 40);
             this.label36.TabIndex = 68;
@@ -2393,7 +2393,7 @@
             // 
             this.label38.AutoSize = true;
             this.label38.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label38.Location = new System.Drawing.Point(281, 480);
+            this.label38.Location = new System.Drawing.Point(282, 480);
             this.label38.Name = "label38";
             this.label38.Size = new System.Drawing.Size(119, 40);
             this.label38.TabIndex = 70;
@@ -2416,7 +2416,7 @@
             this.HeroHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroHotkeyBT.Location = new System.Drawing.Point(128, 563);
             this.HeroHotkeyBT.Name = "HeroHotkeyBT";
-            this.HeroHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroHotkeyBT.TabIndex = 45;
             this.HeroHotkeyBT.Text = "button7";
             this.HeroHotkeyBT.UseVisualStyleBackColor = true;
@@ -2438,7 +2438,7 @@
             this.UpgradeTopPathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.UpgradeTopPathHotkeyBT.Location = new System.Drawing.Point(128, 603);
             this.UpgradeTopPathHotkeyBT.Name = "UpgradeTopPathHotkeyBT";
-            this.UpgradeTopPathHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.UpgradeTopPathHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.UpgradeTopPathHotkeyBT.TabIndex = 46;
             this.UpgradeTopPathHotkeyBT.Text = "button9";
             this.UpgradeTopPathHotkeyBT.UseVisualStyleBackColor = true;
@@ -2448,7 +2448,7 @@
             // 
             this.label42.AutoSize = true;
             this.label42.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label42.Location = new System.Drawing.Point(281, 600);
+            this.label42.Location = new System.Drawing.Point(282, 600);
             this.label42.Name = "label42";
             this.label42.Size = new System.Drawing.Size(119, 40);
             this.label42.TabIndex = 73;
@@ -2481,7 +2481,7 @@
             // 
             this.label45.AutoSize = true;
             this.label45.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label45.Location = new System.Drawing.Point(281, 680);
+            this.label45.Location = new System.Drawing.Point(282, 680);
             this.label45.Name = "label45";
             this.label45.Size = new System.Drawing.Size(119, 40);
             this.label45.TabIndex = 76;
@@ -2503,7 +2503,7 @@
             // 
             this.label47.AutoSize = true;
             this.label47.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label47.Location = new System.Drawing.Point(281, 720);
+            this.label47.Location = new System.Drawing.Point(282, 720);
             this.label47.Name = "label47";
             this.label47.Size = new System.Drawing.Size(119, 40);
             this.label47.TabIndex = 78;
@@ -2526,7 +2526,7 @@
             this.UpgradeBottomPathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.UpgradeBottomPathHotkeyBT.Location = new System.Drawing.Point(128, 643);
             this.UpgradeBottomPathHotkeyBT.Name = "UpgradeBottomPathHotkeyBT";
-            this.UpgradeBottomPathHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.UpgradeBottomPathHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.UpgradeBottomPathHotkeyBT.TabIndex = 91;
             this.UpgradeBottomPathHotkeyBT.Text = "button1";
             this.UpgradeBottomPathHotkeyBT.UseVisualStyleBackColor = true;
@@ -2537,7 +2537,7 @@
             this.SwitchTargetHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SwitchTargetHotkeyBT.Location = new System.Drawing.Point(128, 683);
             this.SwitchTargetHotkeyBT.Name = "SwitchTargetHotkeyBT";
-            this.SwitchTargetHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.SwitchTargetHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SwitchTargetHotkeyBT.TabIndex = 92;
             this.SwitchTargetHotkeyBT.Text = "button2";
             this.SwitchTargetHotkeyBT.UseVisualStyleBackColor = true;
@@ -2548,7 +2548,7 @@
             this.SetFunction1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SetFunction1HotkeyBT.Location = new System.Drawing.Point(128, 723);
             this.SetFunction1HotkeyBT.Name = "SetFunction1HotkeyBT";
-            this.SetFunction1HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.SetFunction1HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SetFunction1HotkeyBT.TabIndex = 93;
             this.SetFunction1HotkeyBT.Text = "button3";
             this.SetFunction1HotkeyBT.UseVisualStyleBackColor = true;
@@ -2559,7 +2559,7 @@
             this.NextRoundHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.NextRoundHotkeyBT.Location = new System.Drawing.Point(128, 763);
             this.NextRoundHotkeyBT.Name = "NextRoundHotkeyBT";
-            this.NextRoundHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.NextRoundHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.NextRoundHotkeyBT.TabIndex = 94;
             this.NextRoundHotkeyBT.Text = "button4";
             this.NextRoundHotkeyBT.UseVisualStyleBackColor = true;
@@ -2568,7 +2568,7 @@
             // UpgradeMiddlePathHotkeyBT
             // 
             this.UpgradeMiddlePathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.UpgradeMiddlePathHotkeyBT.Location = new System.Drawing.Point(406, 603);
+            this.UpgradeMiddlePathHotkeyBT.Location = new System.Drawing.Point(407, 603);
             this.UpgradeMiddlePathHotkeyBT.Name = "UpgradeMiddlePathHotkeyBT";
             this.UpgradeMiddlePathHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.UpgradeMiddlePathHotkeyBT.TabIndex = 99;
@@ -2579,7 +2579,7 @@
             // ReverseSwitchTargetHotkeyBT
             // 
             this.ReverseSwitchTargetHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReverseSwitchTargetHotkeyBT.Location = new System.Drawing.Point(406, 683);
+            this.ReverseSwitchTargetHotkeyBT.Location = new System.Drawing.Point(407, 683);
             this.ReverseSwitchTargetHotkeyBT.Name = "ReverseSwitchTargetHotkeyBT";
             this.ReverseSwitchTargetHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.ReverseSwitchTargetHotkeyBT.TabIndex = 100;
@@ -2590,7 +2590,7 @@
             // SetFunction2HotkeyBT
             // 
             this.SetFunction2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SetFunction2HotkeyBT.Location = new System.Drawing.Point(406, 723);
+            this.SetFunction2HotkeyBT.Location = new System.Drawing.Point(407, 723);
             this.SetFunction2HotkeyBT.Name = "SetFunction2HotkeyBT";
             this.SetFunction2HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SetFunction2HotkeyBT.TabIndex = 101;
@@ -2614,7 +2614,7 @@
             this.Skill11HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill11HotkeyBT.Location = new System.Drawing.Point(128, 1003);
             this.Skill11HotkeyBT.Name = "Skill11HotkeyBT";
-            this.Skill11HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill11HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill11HotkeyBT.TabIndex = 108;
             this.Skill11HotkeyBT.Text = "button18";
             this.Skill11HotkeyBT.UseVisualStyleBackColor = true;
@@ -2623,7 +2623,7 @@
             // Skill10HotkeyBT
             // 
             this.Skill10HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill10HotkeyBT.Location = new System.Drawing.Point(406, 963);
+            this.Skill10HotkeyBT.Location = new System.Drawing.Point(407, 963);
             this.Skill10HotkeyBT.Name = "Skill10HotkeyBT";
             this.Skill10HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill10HotkeyBT.TabIndex = 107;
@@ -2635,7 +2635,7 @@
             // 
             this.label58.AutoSize = true;
             this.label58.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label58.Location = new System.Drawing.Point(281, 960);
+            this.label58.Location = new System.Drawing.Point(282, 960);
             this.label58.Name = "label58";
             this.label58.Size = new System.Drawing.Size(119, 40);
             this.label58.TabIndex = 89;
@@ -2658,7 +2658,7 @@
             this.Skill9HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill9HotkeyBT.Location = new System.Drawing.Point(128, 963);
             this.Skill9HotkeyBT.Name = "Skill9HotkeyBT";
-            this.Skill9HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill9HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill9HotkeyBT.TabIndex = 106;
             this.Skill9HotkeyBT.Text = "button16";
             this.Skill9HotkeyBT.UseVisualStyleBackColor = true;
@@ -2667,7 +2667,7 @@
             // Skill8HotkeyBT
             // 
             this.Skill8HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill8HotkeyBT.Location = new System.Drawing.Point(406, 923);
+            this.Skill8HotkeyBT.Location = new System.Drawing.Point(407, 923);
             this.Skill8HotkeyBT.Name = "Skill8HotkeyBT";
             this.Skill8HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill8HotkeyBT.TabIndex = 98;
@@ -2679,7 +2679,7 @@
             // 
             this.label56.AutoSize = true;
             this.label56.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label56.Location = new System.Drawing.Point(281, 920);
+            this.label56.Location = new System.Drawing.Point(282, 920);
             this.label56.Name = "label56";
             this.label56.Size = new System.Drawing.Size(119, 40);
             this.label56.TabIndex = 87;
@@ -2702,7 +2702,7 @@
             this.Skill7HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill7HotkeyBT.Location = new System.Drawing.Point(128, 923);
             this.Skill7HotkeyBT.Name = "Skill7HotkeyBT";
-            this.Skill7HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill7HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill7HotkeyBT.TabIndex = 105;
             this.Skill7HotkeyBT.Text = "button15";
             this.Skill7HotkeyBT.UseVisualStyleBackColor = true;
@@ -2711,7 +2711,7 @@
             // Skill6HotkeyBT
             // 
             this.Skill6HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill6HotkeyBT.Location = new System.Drawing.Point(406, 883);
+            this.Skill6HotkeyBT.Location = new System.Drawing.Point(407, 883);
             this.Skill6HotkeyBT.Name = "Skill6HotkeyBT";
             this.Skill6HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill6HotkeyBT.TabIndex = 97;
@@ -2723,7 +2723,7 @@
             // 
             this.label54.AutoSize = true;
             this.label54.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label54.Location = new System.Drawing.Point(281, 880);
+            this.label54.Location = new System.Drawing.Point(282, 880);
             this.label54.Name = "label54";
             this.label54.Size = new System.Drawing.Size(119, 40);
             this.label54.TabIndex = 85;
@@ -2746,7 +2746,7 @@
             this.Skill5HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill5HotkeyBT.Location = new System.Drawing.Point(128, 883);
             this.Skill5HotkeyBT.Name = "Skill5HotkeyBT";
-            this.Skill5HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill5HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill5HotkeyBT.TabIndex = 104;
             this.Skill5HotkeyBT.Text = "button14";
             this.Skill5HotkeyBT.UseVisualStyleBackColor = true;
@@ -2755,7 +2755,7 @@
             // Skill4HotkeyBT
             // 
             this.Skill4HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill4HotkeyBT.Location = new System.Drawing.Point(406, 843);
+            this.Skill4HotkeyBT.Location = new System.Drawing.Point(407, 843);
             this.Skill4HotkeyBT.Name = "Skill4HotkeyBT";
             this.Skill4HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill4HotkeyBT.TabIndex = 96;
@@ -2767,7 +2767,7 @@
             // 
             this.label52.AutoSize = true;
             this.label52.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label52.Location = new System.Drawing.Point(281, 840);
+            this.label52.Location = new System.Drawing.Point(282, 840);
             this.label52.Name = "label52";
             this.label52.Size = new System.Drawing.Size(119, 40);
             this.label52.TabIndex = 83;
@@ -2790,7 +2790,7 @@
             this.Skill3HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill3HotkeyBT.Location = new System.Drawing.Point(128, 843);
             this.Skill3HotkeyBT.Name = "Skill3HotkeyBT";
-            this.Skill3HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill3HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill3HotkeyBT.TabIndex = 103;
             this.Skill3HotkeyBT.Text = "button13";
             this.Skill3HotkeyBT.UseVisualStyleBackColor = true;
@@ -2799,7 +2799,7 @@
             // Skill2HotkeyBT
             // 
             this.Skill2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill2HotkeyBT.Location = new System.Drawing.Point(406, 803);
+            this.Skill2HotkeyBT.Location = new System.Drawing.Point(407, 803);
             this.Skill2HotkeyBT.Name = "Skill2HotkeyBT";
             this.Skill2HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill2HotkeyBT.TabIndex = 95;
@@ -2811,7 +2811,7 @@
             // 
             this.label50.AutoSize = true;
             this.label50.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label50.Location = new System.Drawing.Point(281, 800);
+            this.label50.Location = new System.Drawing.Point(282, 800);
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(119, 40);
             this.label50.TabIndex = 81;
@@ -2834,7 +2834,7 @@
             this.Skill1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill1HotkeyBT.Location = new System.Drawing.Point(128, 803);
             this.Skill1HotkeyBT.Name = "Skill1HotkeyBT";
-            this.Skill1HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.Skill1HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill1HotkeyBT.TabIndex = 102;
             this.Skill1HotkeyBT.Text = "button12";
             this.Skill1HotkeyBT.UseVisualStyleBackColor = true;
@@ -2844,7 +2844,7 @@
             // 
             this.label60.AutoSize = true;
             this.label60.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label60.Location = new System.Drawing.Point(281, 1000);
+            this.label60.Location = new System.Drawing.Point(282, 1000);
             this.label60.Name = "label60";
             this.label60.Size = new System.Drawing.Size(119, 40);
             this.label60.TabIndex = 109;
@@ -2854,7 +2854,7 @@
             // Skill12HotkeyBT
             // 
             this.Skill12HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill12HotkeyBT.Location = new System.Drawing.Point(406, 1003);
+            this.Skill12HotkeyBT.Location = new System.Drawing.Point(407, 1003);
             this.Skill12HotkeyBT.Name = "Skill12HotkeyBT";
             this.Skill12HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.Skill12HotkeyBT.TabIndex = 110;
@@ -2866,7 +2866,7 @@
             // 
             this.label61.AutoSize = true;
             this.label61.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label61.Location = new System.Drawing.Point(281, 760);
+            this.label61.Location = new System.Drawing.Point(282, 760);
             this.label61.Name = "label61";
             this.label61.Size = new System.Drawing.Size(119, 40);
             this.label61.TabIndex = 111;
@@ -2876,7 +2876,7 @@
             // ChangeSpeedHotkeyBT
             // 
             this.ChangeSpeedHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ChangeSpeedHotkeyBT.Location = new System.Drawing.Point(406, 763);
+            this.ChangeSpeedHotkeyBT.Location = new System.Drawing.Point(407, 763);
             this.ChangeSpeedHotkeyBT.Name = "ChangeSpeedHotkeyBT";
             this.ChangeSpeedHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.ChangeSpeedHotkeyBT.TabIndex = 112;
@@ -2986,7 +2986,7 @@
             // 
             this.label70.AutoSize = true;
             this.label70.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label70.Location = new System.Drawing.Point(281, 1040);
+            this.label70.Location = new System.Drawing.Point(282, 1040);
             this.label70.Name = "label70";
             this.label70.Size = new System.Drawing.Size(119, 40);
             this.label70.TabIndex = 122;
@@ -2997,7 +2997,7 @@
             // 
             this.label71.AutoSize = true;
             this.label71.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label71.Location = new System.Drawing.Point(281, 1080);
+            this.label71.Location = new System.Drawing.Point(282, 1080);
             this.label71.Name = "label71";
             this.label71.Size = new System.Drawing.Size(119, 40);
             this.label71.TabIndex = 123;
@@ -3008,7 +3008,7 @@
             // 
             this.label72.AutoSize = true;
             this.label72.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label72.Location = new System.Drawing.Point(281, 1120);
+            this.label72.Location = new System.Drawing.Point(282, 1120);
             this.label72.Name = "label72";
             this.label72.Size = new System.Drawing.Size(119, 40);
             this.label72.TabIndex = 124;
@@ -3019,7 +3019,7 @@
             // 
             this.label73.AutoSize = true;
             this.label73.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label73.Location = new System.Drawing.Point(281, 1160);
+            this.label73.Location = new System.Drawing.Point(282, 1160);
             this.label73.Name = "label73";
             this.label73.Size = new System.Drawing.Size(119, 40);
             this.label73.TabIndex = 125;
@@ -3030,7 +3030,7 @@
             // 
             this.label74.AutoSize = true;
             this.label74.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label74.Location = new System.Drawing.Point(281, 1200);
+            this.label74.Location = new System.Drawing.Point(282, 1200);
             this.label74.Name = "label74";
             this.label74.Size = new System.Drawing.Size(119, 40);
             this.label74.TabIndex = 126;
@@ -3041,7 +3041,7 @@
             // 
             this.label75.AutoSize = true;
             this.label75.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label75.Location = new System.Drawing.Point(281, 1240);
+            this.label75.Location = new System.Drawing.Point(282, 1240);
             this.label75.Name = "label75";
             this.label75.Size = new System.Drawing.Size(119, 40);
             this.label75.TabIndex = 127;
@@ -3052,7 +3052,7 @@
             // 
             this.label76.AutoSize = true;
             this.label76.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label76.Location = new System.Drawing.Point(281, 1280);
+            this.label76.Location = new System.Drawing.Point(282, 1280);
             this.label76.Name = "label76";
             this.label76.Size = new System.Drawing.Size(119, 40);
             this.label76.TabIndex = 128;
@@ -3063,7 +3063,7 @@
             // 
             this.label77.AutoSize = true;
             this.label77.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label77.Location = new System.Drawing.Point(281, 1320);
+            this.label77.Location = new System.Drawing.Point(282, 1320);
             this.label77.Name = "label77";
             this.label77.Size = new System.Drawing.Size(119, 40);
             this.label77.TabIndex = 129;
@@ -3075,7 +3075,7 @@
             this.HeroObject1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject1HotkeyBT.Location = new System.Drawing.Point(128, 1043);
             this.HeroObject1HotkeyBT.Name = "HeroObject1HotkeyBT";
-            this.HeroObject1HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject1HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject1HotkeyBT.TabIndex = 130;
             this.HeroObject1HotkeyBT.Text = "button1";
             this.HeroObject1HotkeyBT.UseVisualStyleBackColor = true;
@@ -3084,7 +3084,7 @@
             // HeroObject2HotkeyBT
             // 
             this.HeroObject2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject2HotkeyBT.Location = new System.Drawing.Point(406, 1043);
+            this.HeroObject2HotkeyBT.Location = new System.Drawing.Point(407, 1043);
             this.HeroObject2HotkeyBT.Name = "HeroObject2HotkeyBT";
             this.HeroObject2HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject2HotkeyBT.TabIndex = 131;
@@ -3097,7 +3097,7 @@
             this.HeroObject3HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject3HotkeyBT.Location = new System.Drawing.Point(128, 1083);
             this.HeroObject3HotkeyBT.Name = "HeroObject3HotkeyBT";
-            this.HeroObject3HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject3HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject3HotkeyBT.TabIndex = 132;
             this.HeroObject3HotkeyBT.Text = "button3";
             this.HeroObject3HotkeyBT.UseVisualStyleBackColor = true;
@@ -3106,7 +3106,7 @@
             // HeroObject4HotkeyBT
             // 
             this.HeroObject4HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject4HotkeyBT.Location = new System.Drawing.Point(406, 1083);
+            this.HeroObject4HotkeyBT.Location = new System.Drawing.Point(407, 1083);
             this.HeroObject4HotkeyBT.Name = "HeroObject4HotkeyBT";
             this.HeroObject4HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject4HotkeyBT.TabIndex = 133;
@@ -3119,7 +3119,7 @@
             this.HeroObject5HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject5HotkeyBT.Location = new System.Drawing.Point(128, 1123);
             this.HeroObject5HotkeyBT.Name = "HeroObject5HotkeyBT";
-            this.HeroObject5HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject5HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject5HotkeyBT.TabIndex = 134;
             this.HeroObject5HotkeyBT.Text = "button5";
             this.HeroObject5HotkeyBT.UseVisualStyleBackColor = true;
@@ -3128,7 +3128,7 @@
             // HeroObject6HotkeyBT
             // 
             this.HeroObject6HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject6HotkeyBT.Location = new System.Drawing.Point(406, 1123);
+            this.HeroObject6HotkeyBT.Location = new System.Drawing.Point(407, 1123);
             this.HeroObject6HotkeyBT.Name = "HeroObject6HotkeyBT";
             this.HeroObject6HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject6HotkeyBT.TabIndex = 135;
@@ -3141,7 +3141,7 @@
             this.HeroObject7HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject7HotkeyBT.Location = new System.Drawing.Point(128, 1163);
             this.HeroObject7HotkeyBT.Name = "HeroObject7HotkeyBT";
-            this.HeroObject7HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject7HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject7HotkeyBT.TabIndex = 136;
             this.HeroObject7HotkeyBT.Text = "button7";
             this.HeroObject7HotkeyBT.UseVisualStyleBackColor = true;
@@ -3150,7 +3150,7 @@
             // HeroObject8HotkeyBT
             // 
             this.HeroObject8HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject8HotkeyBT.Location = new System.Drawing.Point(406, 1163);
+            this.HeroObject8HotkeyBT.Location = new System.Drawing.Point(407, 1163);
             this.HeroObject8HotkeyBT.Name = "HeroObject8HotkeyBT";
             this.HeroObject8HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject8HotkeyBT.TabIndex = 137;
@@ -3163,7 +3163,7 @@
             this.HeroObject9HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject9HotkeyBT.Location = new System.Drawing.Point(128, 1203);
             this.HeroObject9HotkeyBT.Name = "HeroObject9HotkeyBT";
-            this.HeroObject9HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject9HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject9HotkeyBT.TabIndex = 138;
             this.HeroObject9HotkeyBT.Text = "button9";
             this.HeroObject9HotkeyBT.UseVisualStyleBackColor = true;
@@ -3172,7 +3172,7 @@
             // HeroObject10HotkeyBT
             // 
             this.HeroObject10HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject10HotkeyBT.Location = new System.Drawing.Point(406, 1203);
+            this.HeroObject10HotkeyBT.Location = new System.Drawing.Point(407, 1203);
             this.HeroObject10HotkeyBT.Name = "HeroObject10HotkeyBT";
             this.HeroObject10HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject10HotkeyBT.TabIndex = 139;
@@ -3185,7 +3185,7 @@
             this.HeroObject11HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject11HotkeyBT.Location = new System.Drawing.Point(128, 1243);
             this.HeroObject11HotkeyBT.Name = "HeroObject11HotkeyBT";
-            this.HeroObject11HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject11HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject11HotkeyBT.TabIndex = 140;
             this.HeroObject11HotkeyBT.Text = "button11";
             this.HeroObject11HotkeyBT.UseVisualStyleBackColor = true;
@@ -3194,7 +3194,7 @@
             // HeroObject12HotkeyBT
             // 
             this.HeroObject12HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject12HotkeyBT.Location = new System.Drawing.Point(406, 1243);
+            this.HeroObject12HotkeyBT.Location = new System.Drawing.Point(407, 1243);
             this.HeroObject12HotkeyBT.Name = "HeroObject12HotkeyBT";
             this.HeroObject12HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject12HotkeyBT.TabIndex = 141;
@@ -3207,7 +3207,7 @@
             this.HeroObject13HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject13HotkeyBT.Location = new System.Drawing.Point(128, 1283);
             this.HeroObject13HotkeyBT.Name = "HeroObject13HotkeyBT";
-            this.HeroObject13HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject13HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject13HotkeyBT.TabIndex = 142;
             this.HeroObject13HotkeyBT.Text = "button13";
             this.HeroObject13HotkeyBT.UseVisualStyleBackColor = true;
@@ -3216,7 +3216,7 @@
             // HeroObject14HotkeyBT
             // 
             this.HeroObject14HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject14HotkeyBT.Location = new System.Drawing.Point(406, 1283);
+            this.HeroObject14HotkeyBT.Location = new System.Drawing.Point(407, 1283);
             this.HeroObject14HotkeyBT.Name = "HeroObject14HotkeyBT";
             this.HeroObject14HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject14HotkeyBT.TabIndex = 143;
@@ -3229,7 +3229,7 @@
             this.HeroObject15HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject15HotkeyBT.Location = new System.Drawing.Point(128, 1323);
             this.HeroObject15HotkeyBT.Name = "HeroObject15HotkeyBT";
-            this.HeroObject15HotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.HeroObject15HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject15HotkeyBT.TabIndex = 144;
             this.HeroObject15HotkeyBT.Text = "button15";
             this.HeroObject15HotkeyBT.UseVisualStyleBackColor = true;
@@ -3238,7 +3238,7 @@
             // HeroObject16HotkeyBT
             // 
             this.HeroObject16HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject16HotkeyBT.Location = new System.Drawing.Point(406, 1323);
+            this.HeroObject16HotkeyBT.Location = new System.Drawing.Point(407, 1323);
             this.HeroObject16HotkeyBT.Name = "HeroObject16HotkeyBT";
             this.HeroObject16HotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.HeroObject16HotkeyBT.TabIndex = 145;
@@ -3250,7 +3250,7 @@
             // 
             this.label78.AutoSize = true;
             this.label78.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label78.Location = new System.Drawing.Point(281, 640);
+            this.label78.Location = new System.Drawing.Point(282, 640);
             this.label78.Name = "label78";
             this.label78.Size = new System.Drawing.Size(119, 40);
             this.label78.TabIndex = 146;
@@ -3260,7 +3260,7 @@
             // SellHotkeyBT
             // 
             this.SellHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SellHotkeyBT.Location = new System.Drawing.Point(406, 643);
+            this.SellHotkeyBT.Location = new System.Drawing.Point(407, 643);
             this.SellHotkeyBT.Name = "SellHotkeyBT";
             this.SellHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.SellHotkeyBT.TabIndex = 147;
@@ -3285,7 +3285,7 @@
             this.DesperadoHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DesperadoHotkeyBT.Location = new System.Drawing.Point(128, 523);
             this.DesperadoHotkeyBT.Name = "DesperadoHotkeyBT";
-            this.DesperadoHotkeyBT.Size = new System.Drawing.Size(147, 34);
+            this.DesperadoHotkeyBT.Size = new System.Drawing.Size(148, 34);
             this.DesperadoHotkeyBT.TabIndex = 149;
             this.DesperadoHotkeyBT.Tag = "6";
             this.DesperadoHotkeyBT.Text = "button1";
@@ -3310,7 +3310,7 @@
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel2.Location = new System.Drawing.Point(112, 1640);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(557, 44);
+            this.panel2.Size = new System.Drawing.Size(558, 44);
             this.panel2.TabIndex = 5;
             // 
             // EnableLoggingCB
@@ -3321,7 +3321,7 @@
             this.EnableLoggingCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EnableLoggingCB.Location = new System.Drawing.Point(0, 0);
             this.EnableLoggingCB.Name = "EnableLoggingCB";
-            this.EnableLoggingCB.Size = new System.Drawing.Size(557, 44);
+            this.EnableLoggingCB.Size = new System.Drawing.Size(558, 44);
             this.EnableLoggingCB.TabIndex = 0;
             this.EnableLoggingCB.Text = "启用日志输出";
             this.EnableLoggingCB.UseVisualStyleBackColor = true;
@@ -3355,13 +3355,13 @@
             this.tableLayoutPanel11.Name = "tableLayoutPanel11";
             this.tableLayoutPanel11.RowCount = 1;
             this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.Size = new System.Drawing.Size(557, 39);
+            this.tableLayoutPanel11.Size = new System.Drawing.Size(558, 39);
             this.tableLayoutPanel11.TabIndex = 7;
             // 
             // AddBundleBT
             // 
             this.AddBundleBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AddBundleBT.Location = new System.Drawing.Point(360, 3);
+            this.AddBundleBT.Location = new System.Drawing.Point(361, 3);
             this.AddBundleBT.Name = "AddBundleBT";
             this.AddBundleBT.Size = new System.Drawing.Size(74, 33);
             this.AddBundleBT.TabIndex = 0;
@@ -3372,7 +3372,7 @@
             // DeleteBundleBT
             // 
             this.DeleteBundleBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DeleteBundleBT.Location = new System.Drawing.Point(460, 3);
+            this.DeleteBundleBT.Location = new System.Drawing.Point(461, 3);
             this.DeleteBundleBT.Name = "DeleteBundleBT";
             this.DeleteBundleBT.Size = new System.Drawing.Size(74, 33);
             this.DeleteBundleBT.TabIndex = 1;
@@ -3388,7 +3388,7 @@
             this.BundleNamesCB.FormattingEnabled = true;
             this.BundleNamesCB.Location = new System.Drawing.Point(3, 3);
             this.BundleNamesCB.Name = "BundleNamesCB";
-            this.BundleNamesCB.Size = new System.Drawing.Size(251, 28);
+            this.BundleNamesCB.Size = new System.Drawing.Size(252, 28);
             this.BundleNamesCB.TabIndex = 2;
             // 
             // tableLayoutPanel23

--- a/BTD6AutoCommunity/UI/Main/Form1.cs
+++ b/BTD6AutoCommunity/UI/Main/Form1.cs
@@ -57,6 +57,10 @@ namespace BTD6AutoCommunity.UI.Main
                     if (!Equals(StartPrgramTC.SelectedIndex, scriptEditorViewModel.SelectedTabIndex))
                     {
                         StartPrgramTC.SelectedIndex = scriptEditorViewModel.SelectedTabIndex;
+                        if (StartPrgramTC.SelectedIndex == 0)
+                        {
+                            startViewModel.UpdateSelectedScript();
+                        }
                     }
                 }
             };

--- a/BTD6AutoCommunity/UI/Main/ScriptEditerPage.cs
+++ b/BTD6AutoCommunity/UI/Main/ScriptEditerPage.cs
@@ -89,9 +89,9 @@ namespace BTD6AutoCommunity.UI.Main
                 {
                     MapCB.InvokeIfRequired(() =>
                     {
-                        if (!Equals(MapCB.SelectedItem, scriptEditorViewModel.SelectedMap))
+                        if (!Equals(MapCB.SelectedValue, scriptEditorViewModel.SelectedMap.Value))
                         {
-                            MapCB.SelectedItem = scriptEditorViewModel.SelectedMap;
+                            MapCB.SelectedValue = scriptEditorViewModel.SelectedMap.Value;
                         }
                     });
                 }
@@ -120,9 +120,9 @@ namespace BTD6AutoCommunity.UI.Main
                 {
                     ModeCB.InvokeIfRequired(() =>
                     {
-                        if (!Equals(ModeCB.SelectedItem, scriptEditorViewModel.SelectedMode))
+                        if (!Equals(ModeCB.SelectedValue, scriptEditorViewModel.SelectedMode.Value))
                         {
-                            ModeCB.SelectedItem = scriptEditorViewModel.SelectedMode;
+                            ModeCB.SelectedValue = scriptEditorViewModel.SelectedMode.Value;
                         }
                     });
                 }
@@ -195,6 +195,17 @@ namespace BTD6AutoCommunity.UI.Main
         private void BindScriptNameTextBox()
         {
             ScriptNameTB.DataBindings.Add("Text", scriptEditorViewModel, "ScriptName");
+
+            scriptEditorViewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(scriptEditorViewModel.ScriptName))
+                {
+                    if (!Equals(ScriptNameTB.Text, scriptEditorViewModel.ScriptName))
+                    {
+                        ScriptNameTB.Text = scriptEditorViewModel.ScriptName;
+                    }
+                }
+            };
         }
 
         private void BindAnchorCoordsControls()

--- a/BTD6AutoCommunity/UI/Main/StartPage.cs
+++ b/BTD6AutoCommunity/UI/Main/StartPage.cs
@@ -149,10 +149,7 @@ namespace BTD6AutoCommunity.UI.Main
                 {
                     ExecuteScriptCB.InvokeIfRequired(() =>
                     {
-                        if (!Equals(ExecuteScriptCB.SelectedItem, startViewModel.SelectedScript))
-                        {
-                            ExecuteScriptCB.SelectedItem = startViewModel.SelectedScript;
-                        }
+                        ExecuteScriptCB.SelectedItem = startViewModel.SelectedScript;
                     });
                 }
             };
@@ -312,9 +309,11 @@ namespace BTD6AutoCommunity.UI.Main
 
         private void BindEditScriptButton()
         {
-            IsStartPageEditButtonClicked = true;
-            EditScriptBT.Click += (s, e) => scriptEditorViewModel.EditScriptCommand.Execute(startViewModel.ScriptFullPath);
+            EditScriptBT.Click += (s, e) =>
+            {
+                IsStartPageEditButtonClicked = true;
+                scriptEditorViewModel.EditScriptCommand.Execute(startViewModel.ScriptFullPath);
+            };
         }
-
     }
 }

--- a/BTD6AutoCommunity/ViewModels/ScriptEditorViewModel.cs
+++ b/BTD6AutoCommunity/ViewModels/ScriptEditorViewModel.cs
@@ -49,7 +49,7 @@ namespace BTD6AutoCommunity.ViewModels
             SelectedDifficulty = DifficultyOptions[0];
 
             ModeOptions = new List<ModeDisplayItem>();
-            foreach (LevelMode mode in Constants.ModesList)
+            foreach (LevelModes mode in Constants.ModesList)
             {
                 ModeOptions.Add(new ModeDisplayItem { Value = mode });
             }
@@ -207,7 +207,7 @@ namespace BTD6AutoCommunity.ViewModels
         {
             if (SelectedHero == null || SelectedMode == null) return;
             if (!Enum.IsDefined(typeof(Heroes), SelectedHero.Value) ||
-                !Enum.IsDefined(typeof(LevelMode), SelectedMode.Value))
+                !Enum.IsDefined(typeof(LevelModes), SelectedMode.Value))
                 return;
             int intTime = DateTime.Now.GetHashCode() % 1000;
             string Time = (intTime > 0 ? intTime : -1 * intTime).ToString();

--- a/BTD6AutoCommunity/ViewModels/ScriptEditorViewModel.cs
+++ b/BTD6AutoCommunity/ViewModels/ScriptEditorViewModel.cs
@@ -530,17 +530,31 @@ namespace BTD6AutoCommunity.ViewModels
 
         private void UpdateCoordinate()
         {
-            if (Argument1 == null || Argument2 == null) return;
-            if (Argument1.SelectedItem == null || Argument2.SelectedItem == null) return;
-            if (Argument1.SelectedItem.Name.Contains("有坐标") || Argument2.SelectedItem.Name.Contains("有坐标"))
+            if (Argument1 != null && Argument1.SelectedItem != null)
             {
-                CoordinateDefinition.IsVisible = true;
-                OnPropertyChanged(nameof(CoordinateDefinition));
+                if (Argument1.SelectedItem.Name.Contains("有坐标"))
+                {
+                    CoordinateDefinition.IsVisible = true;
+                    OnPropertyChanged(nameof(CoordinateDefinition));
+                }
+                if (Argument1.SelectedItem.Name.Contains("无坐标"))
+                {
+                    CoordinateDefinition.IsVisible = false;
+                    OnPropertyChanged(nameof(CoordinateDefinition));
+                }
             }
-            if (Argument1.SelectedItem.Name.Contains("无坐标") || Argument2.SelectedItem.Name.Contains("无坐标"))
+            if (Argument2 != null && Argument2.SelectedItem != null)
             {
-                CoordinateDefinition.IsVisible = false;
-                OnPropertyChanged(nameof(CoordinateDefinition));
+                if (Argument2.SelectedItem.Name.Contains("有坐标"))
+                {
+                    CoordinateDefinition.IsVisible = true;
+                    OnPropertyChanged(nameof(CoordinateDefinition));
+                }
+                if (Argument2.SelectedItem.Name.Contains("无坐标"))
+                {
+                    CoordinateDefinition.IsVisible = false;
+                    OnPropertyChanged(nameof(CoordinateDefinition));
+                }
             }
         }
 

--- a/BTD6AutoCommunity/ViewModels/StartViewModel.cs
+++ b/BTD6AutoCommunity/ViewModels/StartViewModel.cs
@@ -92,6 +92,16 @@ namespace BTD6AutoCommunity.ViewModels
 
         #endregion
 
+        #region 脚本编辑器联动
+
+        public void UpdateSelectedScript()
+        {
+            LoadSelectedScript();
+        }
+
+
+        #endregion
+
         private int selectedTabIndex = 0;
         public int SelectedTabIndex
         {
@@ -462,20 +472,20 @@ namespace BTD6AutoCommunity.ViewModels
             switch (selection.selectedFunction)
             {
                 case FunctionTypes.Custom:
-                    currentStrategy = new CustomStrategy(scriptSettings, logHandler, selection);
+                    currentStrategy = new CustomStrategy(logHandler, selection);
                     break;
                 case FunctionTypes.Collection:
-                    currentStrategy = new CollectionStrategy(scriptSettings, logHandler);
+                    currentStrategy = new CollectionStrategy(logHandler);
                     break;
                 case FunctionTypes.Circulation:
-                    currentStrategy = new CirculationStrategy(scriptSettings, logHandler, selection);
+                    currentStrategy = new CirculationStrategy(logHandler, selection);
                     break;
                 case FunctionTypes.Race:
-                    currentStrategy = new RaceStrategy(scriptSettings, logHandler, selection);
+                    currentStrategy = new RaceStrategy(logHandler, selection);
                     break;
                 case FunctionTypes.BlackBorder:
-                    //ShowInfo("敬请期待！");
-                    return;
+                    currentStrategy = new BlackBorderStrategy(logHandler);
+                    break;
             }
 
             if (currentStrategy == null || !currentStrategy.ReadyToStart) return;


### PR DESCRIPTION
v2.6更新日志：
1. 新增地图棘手的轨道，收集脚本后续会发，也可以自己搓，保持命名一致即可“简单收集、双金收集、快速路径收集”；
2. 新增刷黑框徽章识别，已有徽章会自动跳过，稳定性待测试；
3. 新增游戏状态识别配置文件，现在可在config\State_rules.json中自己配置状态检测颜色参数，支持‘‘与或非’’操作；
4. 修复设置英雄功能时无法选择坐标的问题；
5. 优化日志显示。