### PR TITLE
新增脚本暂停/继续功能，优化主界面与热键支持

### DIFF
--- a/BTD6AutoCommunity/Services/Interfaces/IStrategyExecutor.cs
+++ b/BTD6AutoCommunity/Services/Interfaces/IStrategyExecutor.cs
@@ -11,11 +11,17 @@ namespace BTD6AutoCommunity.Services.Interfaces
     public interface IStrategyExecutor
     {
         bool ReadyToStart { get; }
+        bool IsPaused { get; }
         event Action OnStopTriggered;
         event Action<List<string>> OnGameDataUpdated;
         event Action<ExecutableInstruction> OnCurrentInstructionCompleted;
         event Action<ScriptMetadata> OnScriptLoaded;
         void Start();
+
+        void Pause();
+
+        void Resume();
+
         void Stop();
     }
 }

--- a/BTD6AutoCommunity/Strategies/Base/BaseStrategy.cs
+++ b/BTD6AutoCommunity/Strategies/Base/BaseStrategy.cs
@@ -34,6 +34,7 @@ namespace BTD6AutoCommunity.Strategies.Base
         protected ScreenCapturer screenshotCapturer;
 
         public bool ReadyToStart { get; protected set; } = true;
+        public bool IsPaused { get; protected set; } = false;
 
         // 事件
         public event Action OnStopTriggered;
@@ -191,6 +192,32 @@ namespace BTD6AutoCommunity.Strategies.Base
         protected virtual void OnPreStart() { }
 
         protected virtual void OnPostStart() { }
+
+        public virtual void Pause()
+        {
+            if (IsPaused) return;
+
+            IsPaused = true;
+            _logs.Log("策略已暂停", LogLevel.Info);
+
+            screenShotCaptureTimer?.Stop();
+            LevelDataMonitorTimer?.Stop();
+            InGameActionExecutorTimer?.Stop();
+
+            InputSimulator.ReleaseAllKeys();
+        }
+
+        public virtual void Resume()
+        {
+            if (!IsPaused) return;
+
+            IsPaused = false;
+            _logs.Log("策略已恢复", LogLevel.Info);
+
+            screenShotCaptureTimer?.Start();
+            LevelDataMonitorTimer?.Start();
+            InGameActionExecutorTimer?.Start();
+        }
 
         public virtual void Stop()
         {

--- a/BTD6AutoCommunity/Views/Main/Form1.Designer.cs
+++ b/BTD6AutoCommunity/Views/Main/Form1.Designer.cs
@@ -34,7 +34,6 @@
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.panel1 = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label11 = new System.Windows.Forms.Label();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
@@ -50,8 +49,10 @@
             this.ImportScriptBT = new System.Windows.Forms.Button();
             this.EditScriptBT = new System.Windows.Forms.Button();
             this.OutputScriptBT = new System.Windows.Forms.Button();
-            this.StartProgramBT = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel25 = new System.Windows.Forms.TableLayoutPanel();
+            this.StartProgramBT = new System.Windows.Forms.Button();
+            this.PauseBT = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
             this.label4 = new System.Windows.Forms.Label();
@@ -69,7 +70,6 @@
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.logsRTB = new System.Windows.Forms.RichTextBox();
             this.logsLB = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tableLayoutPanel8 = new System.Windows.Forms.TableLayoutPanel();
@@ -294,6 +294,7 @@
             this.tableLayoutPanel3.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
             this.tableLayoutPanel7.SuspendLayout();
+            this.tableLayoutPanel25.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -338,7 +339,7 @@
             this.ActionsCB.FormattingEnabled = true;
             this.ActionsCB.Location = new System.Drawing.Point(3, 89);
             this.ActionsCB.Name = "ActionsCB";
-            this.ActionsCB.Size = new System.Drawing.Size(137, 28);
+            this.ActionsCB.Size = new System.Drawing.Size(137, 35);
             this.ActionsCB.TabIndex = 9;
             // 
             // StartPrgramTC
@@ -349,7 +350,7 @@
             this.StartPrgramTC.Controls.Add(this.tabPage4);
             this.StartPrgramTC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.StartPrgramTC.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.StartPrgramTC.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.StartPrgramTC.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.StartPrgramTC.ItemSize = new System.Drawing.Size(100, 26);
             this.StartPrgramTC.Location = new System.Drawing.Point(0, 0);
             this.StartPrgramTC.Multiline = true;
@@ -388,30 +389,17 @@
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Controls.Add(this.label11, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel6, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label9, 0, 1);
             this.tableLayoutPanel1.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 21F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 631F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(688, 633);
             this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // label11
-            // 
-            this.label11.AutoSize = true;
-            this.label11.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label11.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label11.Location = new System.Drawing.Point(348, 610);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(335, 21);
-            this.label11.TabIndex = 3;
-            this.label11.Text = "作者：b站@回眸尧遥千里";
             // 
             // tableLayoutPanel2
             // 
@@ -425,10 +413,10 @@
             this.tableLayoutPanel2.Location = new System.Drawing.Point(5, 5);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 3;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 302F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 160F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 92F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(335, 600);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 310F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 135F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(335, 623);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // tableLayoutPanel3
@@ -436,16 +424,16 @@
             this.tableLayoutPanel3.ColumnCount = 1;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Controls.Add(this.tableLayoutPanel4, 0, 0);
-            this.tableLayoutPanel3.Controls.Add(this.StartProgramBT, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this.label3, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.tableLayoutPanel25, 0, 2);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 3;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 197F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 53.125F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 46.875F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(329, 296);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 202F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(329, 304);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // tableLayoutPanel4
@@ -473,7 +461,7 @@
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 38F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 38F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(323, 191);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(323, 196);
             this.tableLayoutPanel4.TabIndex = 0;
             // 
             // label1
@@ -504,25 +492,25 @@
             // 
             this.ExecuteMapCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ExecuteMapCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ExecuteMapCB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.ExecuteMapCB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.ExecuteMapCB.FormattingEnabled = true;
             this.ExecuteMapCB.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ExecuteMapCB.Location = new System.Drawing.Point(66, 41);
             this.ExecuteMapCB.Name = "ExecuteMapCB";
-            this.ExecuteMapCB.Size = new System.Drawing.Size(254, 28);
+            this.ExecuteMapCB.Size = new System.Drawing.Size(254, 35);
             this.ExecuteMapCB.TabIndex = 4;
             // 
             // ExecuteModeCB
             // 
             this.ExecuteModeCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ExecuteModeCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ExecuteModeCB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.ExecuteModeCB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.ExecuteModeCB.FormattingEnabled = true;
             this.ExecuteModeCB.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ExecuteModeCB.Location = new System.Drawing.Point(66, 3);
             this.ExecuteModeCB.Name = "ExecuteModeCB";
             this.ExecuteModeCB.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.ExecuteModeCB.Size = new System.Drawing.Size(254, 28);
+            this.ExecuteModeCB.Size = new System.Drawing.Size(254, 35);
             this.ExecuteModeCB.TabIndex = 3;
             // 
             // DifficultyLB
@@ -541,11 +529,11 @@
             // 
             this.ExecuteDifficultyCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ExecuteDifficultyCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ExecuteDifficultyCB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.ExecuteDifficultyCB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.ExecuteDifficultyCB.FormattingEnabled = true;
             this.ExecuteDifficultyCB.Location = new System.Drawing.Point(66, 79);
             this.ExecuteDifficultyCB.Name = "ExecuteDifficultyCB";
-            this.ExecuteDifficultyCB.Size = new System.Drawing.Size(254, 28);
+            this.ExecuteDifficultyCB.Size = new System.Drawing.Size(254, 35);
             this.ExecuteDifficultyCB.TabIndex = 7;
             // 
             // ScriptLB
@@ -564,20 +552,20 @@
             // 
             this.ExecuteScriptCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ExecuteScriptCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ExecuteScriptCB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.ExecuteScriptCB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.ExecuteScriptCB.FormattingEnabled = true;
             this.ExecuteScriptCB.Location = new System.Drawing.Point(66, 117);
             this.ExecuteScriptCB.Name = "ExecuteScriptCB";
-            this.ExecuteScriptCB.Size = new System.Drawing.Size(254, 28);
+            this.ExecuteScriptCB.Size = new System.Drawing.Size(254, 35);
             this.ExecuteScriptCB.TabIndex = 9;
             // 
             // tableLayoutPanel7
             // 
             this.tableLayoutPanel7.ColumnCount = 4;
             this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
+            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 80F));
+            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 80F));
+            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 80F));
             this.tableLayoutPanel7.Controls.Add(this.ImportScriptBT, 2, 0);
             this.tableLayoutPanel7.Controls.Add(this.EditScriptBT, 1, 0);
             this.tableLayoutPanel7.Controls.Add(this.OutputScriptBT, 3, 0);
@@ -586,16 +574,16 @@
             this.tableLayoutPanel7.Name = "tableLayoutPanel7";
             this.tableLayoutPanel7.RowCount = 1;
             this.tableLayoutPanel7.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel7.Size = new System.Drawing.Size(254, 34);
+            this.tableLayoutPanel7.Size = new System.Drawing.Size(254, 38);
             this.tableLayoutPanel7.TabIndex = 10;
             // 
             // ImportScriptBT
             // 
             this.ImportScriptBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ImportScriptBT.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.ImportScriptBT.Location = new System.Drawing.Point(117, 3);
+            this.ImportScriptBT.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.ImportScriptBT.Location = new System.Drawing.Point(97, 3);
             this.ImportScriptBT.Name = "ImportScriptBT";
-            this.ImportScriptBT.Size = new System.Drawing.Size(64, 28);
+            this.ImportScriptBT.Size = new System.Drawing.Size(74, 32);
             this.ImportScriptBT.TabIndex = 11;
             this.ImportScriptBT.Text = "导入";
             this.ImportScriptBT.UseVisualStyleBackColor = true;
@@ -603,10 +591,10 @@
             // EditScriptBT
             // 
             this.EditScriptBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.EditScriptBT.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.EditScriptBT.Location = new System.Drawing.Point(47, 3);
+            this.EditScriptBT.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.EditScriptBT.Location = new System.Drawing.Point(17, 3);
             this.EditScriptBT.Name = "EditScriptBT";
-            this.EditScriptBT.Size = new System.Drawing.Size(64, 28);
+            this.EditScriptBT.Size = new System.Drawing.Size(74, 32);
             this.EditScriptBT.TabIndex = 12;
             this.EditScriptBT.Text = "编辑";
             this.EditScriptBT.UseVisualStyleBackColor = true;
@@ -614,47 +602,74 @@
             // OutputScriptBT
             // 
             this.OutputScriptBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.OutputScriptBT.Font = new System.Drawing.Font("宋体", 12F);
-            this.OutputScriptBT.Location = new System.Drawing.Point(187, 3);
+            this.OutputScriptBT.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.OutputScriptBT.Location = new System.Drawing.Point(177, 3);
             this.OutputScriptBT.Name = "OutputScriptBT";
-            this.OutputScriptBT.Size = new System.Drawing.Size(64, 28);
+            this.OutputScriptBT.Size = new System.Drawing.Size(74, 32);
             this.OutputScriptBT.TabIndex = 13;
             this.OutputScriptBT.Text = "导出";
             this.OutputScriptBT.UseVisualStyleBackColor = true;
-            // 
-            // StartProgramBT
-            // 
-            this.StartProgramBT.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.StartProgramBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.StartProgramBT.Font = new System.Drawing.Font("新宋体", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.StartProgramBT.Location = new System.Drawing.Point(3, 252);
-            this.StartProgramBT.Name = "StartProgramBT";
-            this.StartProgramBT.Size = new System.Drawing.Size(323, 41);
-            this.StartProgramBT.TabIndex = 2;
-            this.StartProgramBT.Text = "启动";
-            this.StartProgramBT.UseVisualStyleBackColor = true;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
             this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.label3.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.label3.ForeColor = System.Drawing.SystemColors.Highlight;
-            this.label3.Location = new System.Drawing.Point(3, 197);
+            this.label3.Location = new System.Drawing.Point(3, 202);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(323, 52);
             this.label3.TabIndex = 3;
-            this.label3.Text = "启动/终止快捷键F1\r\n点击启动后，需点击游戏窗口";
+            this.label3.Text = "启动/终止快捷键F10，暂停F9\r\n点击启动后，需点击游戏窗口";
             this.label3.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
+            // 
+            // tableLayoutPanel25
+            // 
+            this.tableLayoutPanel25.ColumnCount = 2;
+            this.tableLayoutPanel25.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel25.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel25.Controls.Add(this.StartProgramBT, 0, 0);
+            this.tableLayoutPanel25.Controls.Add(this.PauseBT, 1, 0);
+            this.tableLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel25.Location = new System.Drawing.Point(3, 257);
+            this.tableLayoutPanel25.Name = "tableLayoutPanel25";
+            this.tableLayoutPanel25.RowCount = 1;
+            this.tableLayoutPanel25.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel25.Size = new System.Drawing.Size(323, 44);
+            this.tableLayoutPanel25.TabIndex = 4;
+            // 
+            // StartProgramBT
+            // 
+            this.StartProgramBT.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.StartProgramBT.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.StartProgramBT.Font = new System.Drawing.Font("微软雅黑", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.StartProgramBT.Location = new System.Drawing.Point(3, 3);
+            this.StartProgramBT.Name = "StartProgramBT";
+            this.StartProgramBT.Size = new System.Drawing.Size(155, 38);
+            this.StartProgramBT.TabIndex = 2;
+            this.StartProgramBT.Text = "启动";
+            this.StartProgramBT.UseVisualStyleBackColor = true;
+            // 
+            // PauseBT
+            // 
+            this.PauseBT.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.PauseBT.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.PauseBT.Font = new System.Drawing.Font("微软雅黑", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.PauseBT.Location = new System.Drawing.Point(164, 3);
+            this.PauseBT.Name = "PauseBT";
+            this.PauseBT.Size = new System.Drawing.Size(156, 38);
+            this.PauseBT.TabIndex = 3;
+            this.PauseBT.Text = "暂停";
+            this.PauseBT.UseVisualStyleBackColor = true;
             // 
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.tableLayoutPanel5);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Font = new System.Drawing.Font("宋体", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.groupBox1.Location = new System.Drawing.Point(3, 465);
+            this.groupBox1.Font = new System.Drawing.Font("微软雅黑", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.groupBox1.Location = new System.Drawing.Point(3, 491);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(329, 132);
+            this.groupBox1.Size = new System.Drawing.Size(329, 129);
             this.groupBox1.TabIndex = 3;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "回合信息";
@@ -671,14 +686,14 @@
             this.tableLayoutPanel5.Controls.Add(this.CurrentGoldLB, 1, 1);
             this.tableLayoutPanel5.Controls.Add(this.CurrentLifeLB, 1, 2);
             this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 24);
+            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 27);
             this.tableLayoutPanel5.Name = "tableLayoutPanel5";
             this.tableLayoutPanel5.RowCount = 4;
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel5.Size = new System.Drawing.Size(323, 105);
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(323, 99);
             this.tableLayoutPanel5.TabIndex = 1;
             // 
             // label4
@@ -721,48 +736,48 @@
             // 
             this.CurrentRoundLB.AutoSize = true;
             this.CurrentRoundLB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CurrentRoundLB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.CurrentRoundLB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.CurrentRoundLB.Location = new System.Drawing.Point(103, 0);
             this.CurrentRoundLB.Name = "CurrentRoundLB";
             this.CurrentRoundLB.Size = new System.Drawing.Size(217, 32);
             this.CurrentRoundLB.TabIndex = 3;
-            this.CurrentRoundLB.Text = "None";
+            this.CurrentRoundLB.Text = "无";
             this.CurrentRoundLB.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CurrentGoldLB
             // 
             this.CurrentGoldLB.AutoSize = true;
             this.CurrentGoldLB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CurrentGoldLB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.CurrentGoldLB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.CurrentGoldLB.ForeColor = System.Drawing.Color.DarkGoldenrod;
             this.CurrentGoldLB.Location = new System.Drawing.Point(103, 32);
             this.CurrentGoldLB.Name = "CurrentGoldLB";
             this.CurrentGoldLB.Size = new System.Drawing.Size(217, 32);
             this.CurrentGoldLB.TabIndex = 4;
-            this.CurrentGoldLB.Text = "None";
+            this.CurrentGoldLB.Text = "无";
             this.CurrentGoldLB.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CurrentLifeLB
             // 
             this.CurrentLifeLB.AutoSize = true;
             this.CurrentLifeLB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CurrentLifeLB.Font = new System.Drawing.Font("宋体", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.CurrentLifeLB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.CurrentLifeLB.ForeColor = System.Drawing.Color.DarkRed;
             this.CurrentLifeLB.Location = new System.Drawing.Point(103, 64);
             this.CurrentLifeLB.Name = "CurrentLifeLB";
             this.CurrentLifeLB.Size = new System.Drawing.Size(217, 32);
             this.CurrentLifeLB.TabIndex = 5;
-            this.CurrentLifeLB.Text = "None";
+            this.CurrentLifeLB.Text = "无";
             this.CurrentLifeLB.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.tableLayoutPanel22);
             this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Font = new System.Drawing.Font("宋体", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.groupBox2.Location = new System.Drawing.Point(3, 305);
+            this.groupBox2.Font = new System.Drawing.Font("微软雅黑", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.groupBox2.Location = new System.Drawing.Point(3, 313);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(329, 154);
+            this.groupBox2.Size = new System.Drawing.Size(329, 172);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "指令预览";
@@ -774,22 +789,23 @@
             this.tableLayoutPanel22.Controls.Add(this.CurrentTriggerRTB, 0, 1);
             this.tableLayoutPanel22.Controls.Add(this.CurrentInstructionRTB, 0, 0);
             this.tableLayoutPanel22.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel22.Location = new System.Drawing.Point(3, 24);
+            this.tableLayoutPanel22.Location = new System.Drawing.Point(3, 27);
             this.tableLayoutPanel22.Name = "tableLayoutPanel22";
             this.tableLayoutPanel22.RowCount = 2;
-            this.tableLayoutPanel22.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel22.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel22.Size = new System.Drawing.Size(323, 127);
+            this.tableLayoutPanel22.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel22.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel22.Size = new System.Drawing.Size(323, 142);
             this.tableLayoutPanel22.TabIndex = 2;
             // 
             // CurrentTriggerRTB
             // 
             this.CurrentTriggerRTB.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.CurrentTriggerRTB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CurrentTriggerRTB.Location = new System.Drawing.Point(3, 68);
+            this.CurrentTriggerRTB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.CurrentTriggerRTB.Location = new System.Drawing.Point(3, 74);
             this.CurrentTriggerRTB.Name = "CurrentTriggerRTB";
             this.CurrentTriggerRTB.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.CurrentTriggerRTB.Size = new System.Drawing.Size(317, 59);
+            this.CurrentTriggerRTB.Size = new System.Drawing.Size(317, 65);
             this.CurrentTriggerRTB.TabIndex = 2;
             this.CurrentTriggerRTB.Text = "触发条件";
             // 
@@ -797,9 +813,11 @@
             // 
             this.CurrentInstructionRTB.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.CurrentInstructionRTB.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.CurrentInstructionRTB.Font = new System.Drawing.Font("微软雅黑", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.CurrentInstructionRTB.Location = new System.Drawing.Point(3, 3);
             this.CurrentInstructionRTB.Name = "CurrentInstructionRTB";
-            this.CurrentInstructionRTB.Size = new System.Drawing.Size(317, 59);
+            this.CurrentInstructionRTB.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.CurrentInstructionRTB.Size = new System.Drawing.Size(317, 65);
             this.CurrentInstructionRTB.TabIndex = 3;
             this.CurrentInstructionRTB.Text = "当前指令";
             // 
@@ -817,7 +835,7 @@
             this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel6.Size = new System.Drawing.Size(335, 600);
+            this.tableLayoutPanel6.Size = new System.Drawing.Size(335, 623);
             this.tableLayoutPanel6.TabIndex = 1;
             // 
             // PreviewLB
@@ -825,10 +843,10 @@
             this.PreviewLB.AllowDrop = true;
             this.PreviewLB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.PreviewLB.FormattingEnabled = true;
-            this.PreviewLB.ItemHeight = 20;
+            this.PreviewLB.ItemHeight = 27;
             this.PreviewLB.Location = new System.Drawing.Point(3, 8);
             this.PreviewLB.Name = "PreviewLB";
-            this.PreviewLB.Size = new System.Drawing.Size(329, 291);
+            this.PreviewLB.Size = new System.Drawing.Size(329, 303);
             this.PreviewLB.TabIndex = 1;
             // 
             // groupBox3
@@ -836,10 +854,10 @@
             this.groupBox3.Controls.Add(this.logsRTB);
             this.groupBox3.Controls.Add(this.logsLB);
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox3.Font = new System.Drawing.Font("宋体", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
-            this.groupBox3.Location = new System.Drawing.Point(3, 305);
+            this.groupBox3.Font = new System.Drawing.Font("微软雅黑", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.groupBox3.Location = new System.Drawing.Point(3, 317);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(329, 292);
+            this.groupBox3.Size = new System.Drawing.Size(329, 303);
             this.groupBox3.TabIndex = 4;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "运行日志";
@@ -847,10 +865,10 @@
             // logsRTB
             // 
             this.logsRTB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.logsRTB.Location = new System.Drawing.Point(3, 24);
+            this.logsRTB.Location = new System.Drawing.Point(3, 27);
             this.logsRTB.Name = "logsRTB";
             this.logsRTB.ReadOnly = true;
-            this.logsRTB.Size = new System.Drawing.Size(323, 265);
+            this.logsRTB.Size = new System.Drawing.Size(323, 273);
             this.logsRTB.TabIndex = 1;
             this.logsRTB.Text = "";
             // 
@@ -858,21 +876,10 @@
             // 
             this.logsLB.AutoSize = true;
             this.logsLB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.logsLB.Location = new System.Drawing.Point(3, 24);
+            this.logsLB.Location = new System.Drawing.Point(3, 27);
             this.logsLB.Name = "logsLB";
-            this.logsLB.Size = new System.Drawing.Size(0, 18);
+            this.logsLB.Size = new System.Drawing.Size(0, 24);
             this.logsLB.TabIndex = 0;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label9.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label9.Location = new System.Drawing.Point(5, 610);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(335, 21);
-            this.label9.TabIndex = 2;
-            this.label9.Text = "QQ交流群：960225891";
             // 
             // tabPage2
             // 
@@ -945,7 +952,7 @@
             this.label14.AutoSize = true;
             this.label14.Location = new System.Drawing.Point(3, 0);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(49, 20);
+            this.label14.Size = new System.Drawing.Size(52, 27);
             this.label14.TabIndex = 0;
             this.label14.Text = "分类";
             // 
@@ -956,7 +963,7 @@
             this.MapCB.FormattingEnabled = true;
             this.MapCB.Location = new System.Drawing.Point(3, 87);
             this.MapCB.Name = "MapCB";
-            this.MapCB.Size = new System.Drawing.Size(137, 28);
+            this.MapCB.Size = new System.Drawing.Size(137, 35);
             this.MapCB.TabIndex = 1;
             // 
             // DifficultyCB
@@ -970,7 +977,7 @@
             "困难"});
             this.DifficultyCB.Location = new System.Drawing.Point(3, 129);
             this.DifficultyCB.Name = "DifficultyCB";
-            this.DifficultyCB.Size = new System.Drawing.Size(137, 28);
+            this.DifficultyCB.Size = new System.Drawing.Size(137, 35);
             this.DifficultyCB.TabIndex = 3;
             // 
             // ModeCB
@@ -980,7 +987,7 @@
             this.ModeCB.FormattingEnabled = true;
             this.ModeCB.Location = new System.Drawing.Point(3, 171);
             this.ModeCB.Name = "ModeCB";
-            this.ModeCB.Size = new System.Drawing.Size(137, 28);
+            this.ModeCB.Size = new System.Drawing.Size(137, 35);
             this.ModeCB.TabIndex = 5;
             // 
             // HeroCB
@@ -990,11 +997,12 @@
             this.HeroCB.FormattingEnabled = true;
             this.HeroCB.Location = new System.Drawing.Point(3, 213);
             this.HeroCB.Name = "HeroCB";
-            this.HeroCB.Size = new System.Drawing.Size(137, 28);
+            this.HeroCB.Size = new System.Drawing.Size(137, 35);
             this.HeroCB.TabIndex = 7;
             // 
             // AnchorCoordsBT
             // 
+            this.AnchorCoordsBT.Cursor = System.Windows.Forms.Cursors.Hand;
             this.AnchorCoordsBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AnchorCoordsBT.Location = new System.Drawing.Point(3, 545);
             this.AnchorCoordsBT.Name = "AnchorCoordsBT";
@@ -1078,7 +1086,7 @@
             this.ScriptNameTB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ScriptNameTB.Location = new System.Drawing.Point(3, 297);
             this.ScriptNameTB.Name = "ScriptNameTB";
-            this.ScriptNameTB.Size = new System.Drawing.Size(137, 30);
+            this.ScriptNameTB.Size = new System.Drawing.Size(137, 34);
             this.ScriptNameTB.TabIndex = 11;
             // 
             // splitContainer2
@@ -1147,7 +1155,7 @@
             this.label15.AutoSize = true;
             this.label15.Location = new System.Drawing.Point(3, 0);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(49, 20);
+            this.label15.Size = new System.Drawing.Size(52, 27);
             this.label15.TabIndex = 8;
             this.label15.Text = "指令";
             // 
@@ -1157,7 +1165,7 @@
             this.Argument1CB.FormattingEnabled = true;
             this.Argument1CB.Location = new System.Drawing.Point(3, 175);
             this.Argument1CB.Name = "Argument1CB";
-            this.Argument1CB.Size = new System.Drawing.Size(137, 28);
+            this.Argument1CB.Size = new System.Drawing.Size(137, 35);
             this.Argument1CB.TabIndex = 10;
             this.Argument1CB.Text = "参数1";
             // 
@@ -1189,7 +1197,7 @@
             this.Argument2CB.FormattingEnabled = true;
             this.Argument2CB.Location = new System.Drawing.Point(3, 218);
             this.Argument2CB.Name = "Argument2CB";
-            this.Argument2CB.Size = new System.Drawing.Size(137, 28);
+            this.Argument2CB.Size = new System.Drawing.Size(137, 35);
             this.Argument2CB.TabIndex = 15;
             this.Argument2CB.Text = "参数2";
             // 
@@ -1287,6 +1295,7 @@
             // 
             // ModifyInstructionBT
             // 
+            this.ModifyInstructionBT.Cursor = System.Windows.Forms.Cursors.Hand;
             this.ModifyInstructionBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModifyInstructionBT.Location = new System.Drawing.Point(3, 513);
             this.ModifyInstructionBT.Name = "ModifyInstructionBT";
@@ -1297,6 +1306,7 @@
             // 
             // InsertInstructionBT
             // 
+            this.InsertInstructionBT.Cursor = System.Windows.Forms.Cursors.Hand;
             this.InsertInstructionBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.InsertInstructionBT.Location = new System.Drawing.Point(3, 553);
             this.InsertInstructionBT.Name = "InsertInstructionBT";
@@ -1310,7 +1320,7 @@
             this.RoundTriggerTB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RoundTriggerTB.Location = new System.Drawing.Point(3, 304);
             this.RoundTriggerTB.Name = "RoundTriggerTB";
-            this.RoundTriggerTB.Size = new System.Drawing.Size(137, 30);
+            this.RoundTriggerTB.Size = new System.Drawing.Size(137, 34);
             this.RoundTriggerTB.TabIndex = 23;
             // 
             // CoinTriggerTB
@@ -1318,7 +1328,7 @@
             this.CoinTriggerTB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CoinTriggerTB.Location = new System.Drawing.Point(3, 390);
             this.CoinTriggerTB.Name = "CoinTriggerTB";
-            this.CoinTriggerTB.Size = new System.Drawing.Size(137, 30);
+            this.CoinTriggerTB.Size = new System.Drawing.Size(137, 34);
             this.CoinTriggerTB.TabIndex = 24;
             // 
             // tableLayoutPanel10
@@ -1327,6 +1337,7 @@
             this.tableLayoutPanel10.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel10.Controls.Add(this.InstructionsViewLB, 0, 0);
             this.tableLayoutPanel10.Controls.Add(this.tableLayoutPanel12, 0, 1);
+            this.tableLayoutPanel10.Cursor = System.Windows.Forms.Cursors.Default;
             this.tableLayoutPanel10.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel10.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel10.Name = "tableLayoutPanel10";
@@ -1362,6 +1373,7 @@
             this.tableLayoutPanel12.Controls.Add(this.ClearInstructionsBT, 1, 1);
             this.tableLayoutPanel12.Controls.Add(this.SaveInstructionsBT, 1, 2);
             this.tableLayoutPanel12.Controls.Add(this.BuildInstructionsBT, 0, 2);
+            this.tableLayoutPanel12.Cursor = System.Windows.Forms.Cursors.Default;
             this.tableLayoutPanel12.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel12.Location = new System.Drawing.Point(3, 509);
             this.tableLayoutPanel12.Name = "tableLayoutPanel12";
@@ -1407,6 +1419,7 @@
             // 
             // ClearInstructionsBT
             // 
+            this.ClearInstructionsBT.Cursor = System.Windows.Forms.Cursors.Hand;
             this.ClearInstructionsBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ClearInstructionsBT.Location = new System.Drawing.Point(194, 43);
             this.ClearInstructionsBT.Name = "ClearInstructionsBT";
@@ -1530,7 +1543,7 @@
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel19.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel19.Size = new System.Drawing.Size(553, 202);
+            this.tableLayoutPanel19.Size = new System.Drawing.Size(555, 202);
             this.tableLayoutPanel19.TabIndex = 1;
             // 
             // label10
@@ -1552,7 +1565,7 @@
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(254, 40);
             this.label7.TabIndex = 0;
-            this.label7.Text = "游戏数据获取间隔（ms）";
+            this.label7.Text = "数据获取间隔（ms）";
             this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // GetGameDataIntervalUD
@@ -1655,7 +1668,7 @@
             this.EnableFastPathCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EnableFastPathCB.Location = new System.Drawing.Point(263, 163);
             this.EnableFastPathCB.Name = "EnableFastPathCB";
-            this.EnableFastPathCB.Size = new System.Drawing.Size(287, 36);
+            this.EnableFastPathCB.Size = new System.Drawing.Size(289, 36);
             this.EnableFastPathCB.TabIndex = 7;
             this.EnableFastPathCB.Text = "快速路径";
             this.EnableFastPathCB.UseVisualStyleBackColor = true;
@@ -1861,7 +1874,7 @@
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel17.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel17.Size = new System.Drawing.Size(553, 1374);
+            this.tableLayoutPanel17.Size = new System.Drawing.Size(555, 1374);
             this.tableLayoutPanel17.TabIndex = 3;
             // 
             // SpikeFactoryHotkeyBT
@@ -1869,7 +1882,7 @@
             this.SpikeFactoryHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SpikeFactoryHotkeyBT.Location = new System.Drawing.Point(128, 443);
             this.SpikeFactoryHotkeyBT.Name = "SpikeFactoryHotkeyBT";
-            this.SpikeFactoryHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.SpikeFactoryHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.SpikeFactoryHotkeyBT.TabIndex = 41;
             this.SpikeFactoryHotkeyBT.Tag = "31";
             this.SpikeFactoryHotkeyBT.Text = "button42";
@@ -1879,9 +1892,9 @@
             // BananaFarmHotkeyBT
             // 
             this.BananaFarmHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BananaFarmHotkeyBT.Location = new System.Drawing.Point(404, 403);
+            this.BananaFarmHotkeyBT.Location = new System.Drawing.Point(405, 403);
             this.BananaFarmHotkeyBT.Name = "BananaFarmHotkeyBT";
-            this.BananaFarmHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.BananaFarmHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.BananaFarmHotkeyBT.TabIndex = 39;
             this.BananaFarmHotkeyBT.Tag = "30";
             this.BananaFarmHotkeyBT.Text = "30";
@@ -1893,7 +1906,7 @@
             this.MerMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MerMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 403);
             this.MerMonkeyHotkeyBT.Name = "MerMonkeyHotkeyBT";
-            this.MerMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.MerMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.MerMonkeyHotkeyBT.TabIndex = 37;
             this.MerMonkeyHotkeyBT.Tag = "25";
             this.MerMonkeyHotkeyBT.Text = "button38";
@@ -1903,9 +1916,9 @@
             // DruidHotkeyBT
             // 
             this.DruidHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DruidHotkeyBT.Location = new System.Drawing.Point(404, 363);
+            this.DruidHotkeyBT.Location = new System.Drawing.Point(405, 363);
             this.DruidHotkeyBT.Name = "DruidHotkeyBT";
-            this.DruidHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.DruidHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.DruidHotkeyBT.TabIndex = 35;
             this.DruidHotkeyBT.Tag = "24";
             this.DruidHotkeyBT.Text = "button36";
@@ -1917,7 +1930,7 @@
             this.AlchemistHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AlchemistHotkeyBT.Location = new System.Drawing.Point(128, 363);
             this.AlchemistHotkeyBT.Name = "AlchemistHotkeyBT";
-            this.AlchemistHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.AlchemistHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.AlchemistHotkeyBT.TabIndex = 33;
             this.AlchemistHotkeyBT.Tag = "23";
             this.AlchemistHotkeyBT.Text = "button34";
@@ -1927,9 +1940,9 @@
             // NinjaMonkeyHotkeyBT
             // 
             this.NinjaMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.NinjaMonkeyHotkeyBT.Location = new System.Drawing.Point(404, 323);
+            this.NinjaMonkeyHotkeyBT.Location = new System.Drawing.Point(405, 323);
             this.NinjaMonkeyHotkeyBT.Name = "NinjaMonkeyHotkeyBT";
-            this.NinjaMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.NinjaMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.NinjaMonkeyHotkeyBT.TabIndex = 31;
             this.NinjaMonkeyHotkeyBT.Tag = "22";
             this.NinjaMonkeyHotkeyBT.Text = "button32";
@@ -1941,7 +1954,7 @@
             this.SuperMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SuperMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 323);
             this.SuperMonkeyHotkeyBT.Name = "SuperMonkeyHotkeyBT";
-            this.SuperMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.SuperMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.SuperMonkeyHotkeyBT.TabIndex = 29;
             this.SuperMonkeyHotkeyBT.Tag = "21";
             this.SuperMonkeyHotkeyBT.Text = "button30";
@@ -1951,9 +1964,9 @@
             // WizardMonkeyHotkeyBT
             // 
             this.WizardMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.WizardMonkeyHotkeyBT.Location = new System.Drawing.Point(404, 283);
+            this.WizardMonkeyHotkeyBT.Location = new System.Drawing.Point(405, 283);
             this.WizardMonkeyHotkeyBT.Name = "WizardMonkeyHotkeyBT";
-            this.WizardMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.WizardMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.WizardMonkeyHotkeyBT.TabIndex = 27;
             this.WizardMonkeyHotkeyBT.Tag = "20";
             this.WizardMonkeyHotkeyBT.Text = "20";
@@ -1965,7 +1978,7 @@
             this.DartlingGunnerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DartlingGunnerHotkeyBT.Location = new System.Drawing.Point(128, 283);
             this.DartlingGunnerHotkeyBT.Name = "DartlingGunnerHotkeyBT";
-            this.DartlingGunnerHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.DartlingGunnerHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.DartlingGunnerHotkeyBT.TabIndex = 25;
             this.DartlingGunnerHotkeyBT.Tag = "16";
             this.DartlingGunnerHotkeyBT.Text = "button26";
@@ -1975,9 +1988,9 @@
             // MortarMonkeyHotkeyBT
             // 
             this.MortarMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MortarMonkeyHotkeyBT.Location = new System.Drawing.Point(404, 243);
+            this.MortarMonkeyHotkeyBT.Location = new System.Drawing.Point(405, 243);
             this.MortarMonkeyHotkeyBT.Name = "MortarMonkeyHotkeyBT";
-            this.MortarMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.MortarMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.MortarMonkeyHotkeyBT.TabIndex = 23;
             this.MortarMonkeyHotkeyBT.Tag = "15";
             this.MortarMonkeyHotkeyBT.Text = "button24";
@@ -1989,7 +2002,7 @@
             this.HeliPilotHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeliPilotHotkeyBT.Location = new System.Drawing.Point(128, 243);
             this.HeliPilotHotkeyBT.Name = "HeliPilotHotkeyBT";
-            this.HeliPilotHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeliPilotHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeliPilotHotkeyBT.TabIndex = 21;
             this.HeliPilotHotkeyBT.Tag = "14";
             this.HeliPilotHotkeyBT.Text = "button22";
@@ -1999,9 +2012,9 @@
             // MonkeyAceHotkeyBT
             // 
             this.MonkeyAceHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeyAceHotkeyBT.Location = new System.Drawing.Point(404, 203);
+            this.MonkeyAceHotkeyBT.Location = new System.Drawing.Point(405, 203);
             this.MonkeyAceHotkeyBT.Name = "MonkeyAceHotkeyBT";
-            this.MonkeyAceHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.MonkeyAceHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.MonkeyAceHotkeyBT.TabIndex = 19;
             this.MonkeyAceHotkeyBT.Tag = "13";
             this.MonkeyAceHotkeyBT.Text = "button20";
@@ -2013,7 +2026,7 @@
             this.MonkeyBuccaneerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MonkeyBuccaneerHotkeyBT.Location = new System.Drawing.Point(128, 203);
             this.MonkeyBuccaneerHotkeyBT.Name = "MonkeyBuccaneerHotkeyBT";
-            this.MonkeyBuccaneerHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.MonkeyBuccaneerHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.MonkeyBuccaneerHotkeyBT.TabIndex = 17;
             this.MonkeyBuccaneerHotkeyBT.Tag = "12";
             this.MonkeyBuccaneerHotkeyBT.Text = "button18";
@@ -2023,9 +2036,9 @@
             // MonkeySubHotkeyBT
             // 
             this.MonkeySubHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeySubHotkeyBT.Location = new System.Drawing.Point(404, 163);
+            this.MonkeySubHotkeyBT.Location = new System.Drawing.Point(405, 163);
             this.MonkeySubHotkeyBT.Name = "MonkeySubHotkeyBT";
-            this.MonkeySubHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.MonkeySubHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.MonkeySubHotkeyBT.TabIndex = 15;
             this.MonkeySubHotkeyBT.Tag = "11";
             this.MonkeySubHotkeyBT.Text = "button16";
@@ -2037,7 +2050,7 @@
             this.SniperMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SniperMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 163);
             this.SniperMonkeyHotkeyBT.Name = "SniperMonkeyHotkeyBT";
-            this.SniperMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.SniperMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.SniperMonkeyHotkeyBT.TabIndex = 13;
             this.SniperMonkeyHotkeyBT.Tag = "10";
             this.SniperMonkeyHotkeyBT.Text = "button14";
@@ -2047,9 +2060,9 @@
             // GlueGunnerHotkeyBT
             // 
             this.GlueGunnerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GlueGunnerHotkeyBT.Location = new System.Drawing.Point(404, 123);
+            this.GlueGunnerHotkeyBT.Location = new System.Drawing.Point(405, 123);
             this.GlueGunnerHotkeyBT.Name = "GlueGunnerHotkeyBT";
-            this.GlueGunnerHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.GlueGunnerHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.GlueGunnerHotkeyBT.TabIndex = 11;
             this.GlueGunnerHotkeyBT.Tag = "5";
             this.GlueGunnerHotkeyBT.Text = "button12";
@@ -2061,7 +2074,7 @@
             this.IceMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.IceMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 123);
             this.IceMonkeyHotkeyBT.Name = "IceMonkeyHotkeyBT";
-            this.IceMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.IceMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.IceMonkeyHotkeyBT.TabIndex = 9;
             this.IceMonkeyHotkeyBT.Tag = "4";
             this.IceMonkeyHotkeyBT.Text = "button10";
@@ -2071,9 +2084,9 @@
             // TackShooterHotkeyBT
             // 
             this.TackShooterHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.TackShooterHotkeyBT.Location = new System.Drawing.Point(404, 83);
+            this.TackShooterHotkeyBT.Location = new System.Drawing.Point(405, 83);
             this.TackShooterHotkeyBT.Name = "TackShooterHotkeyBT";
-            this.TackShooterHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.TackShooterHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.TackShooterHotkeyBT.TabIndex = 7;
             this.TackShooterHotkeyBT.Tag = "3";
             this.TackShooterHotkeyBT.Text = "button8";
@@ -2085,7 +2098,7 @@
             this.BombShooterHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.BombShooterHotkeyBT.Location = new System.Drawing.Point(128, 83);
             this.BombShooterHotkeyBT.Name = "BombShooterHotkeyBT";
-            this.BombShooterHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.BombShooterHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.BombShooterHotkeyBT.TabIndex = 5;
             this.BombShooterHotkeyBT.Tag = "2";
             this.BombShooterHotkeyBT.Text = "button6";
@@ -2097,7 +2110,7 @@
             this.DartMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DartMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 43);
             this.DartMonkeyHotkeyBT.Name = "DartMonkeyHotkeyBT";
-            this.DartMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.DartMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.DartMonkeyHotkeyBT.TabIndex = 0;
             this.DartMonkeyHotkeyBT.Tag = "";
             this.DartMonkeyHotkeyBT.Text = "Hot1";
@@ -2107,9 +2120,9 @@
             // BoomerangMonkeyHotkeyBT
             // 
             this.BoomerangMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BoomerangMonkeyHotkeyBT.Location = new System.Drawing.Point(404, 43);
+            this.BoomerangMonkeyHotkeyBT.Location = new System.Drawing.Point(405, 43);
             this.BoomerangMonkeyHotkeyBT.Name = "BoomerangMonkeyHotkeyBT";
-            this.BoomerangMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.BoomerangMonkeyHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.BoomerangMonkeyHotkeyBT.TabIndex = 1;
             this.BoomerangMonkeyHotkeyBT.Tag = "1";
             this.BoomerangMonkeyHotkeyBT.Text = "button2";
@@ -2119,9 +2132,9 @@
             // MonkeyVillageHotkeyBT
             // 
             this.MonkeyVillageHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MonkeyVillageHotkeyBT.Location = new System.Drawing.Point(404, 443);
+            this.MonkeyVillageHotkeyBT.Location = new System.Drawing.Point(405, 443);
             this.MonkeyVillageHotkeyBT.Name = "MonkeyVillageHotkeyBT";
-            this.MonkeyVillageHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.MonkeyVillageHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.MonkeyVillageHotkeyBT.TabIndex = 42;
             this.MonkeyVillageHotkeyBT.Tag = "32";
             this.MonkeyVillageHotkeyBT.Text = "button3";
@@ -2133,7 +2146,7 @@
             this.EngineerMonkeyHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EngineerMonkeyHotkeyBT.Location = new System.Drawing.Point(128, 483);
             this.EngineerMonkeyHotkeyBT.Name = "EngineerMonkeyHotkeyBT";
-            this.EngineerMonkeyHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.EngineerMonkeyHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.EngineerMonkeyHotkeyBT.TabIndex = 43;
             this.EngineerMonkeyHotkeyBT.Tag = "33";
             this.EngineerMonkeyHotkeyBT.Text = "button4";
@@ -2143,9 +2156,9 @@
             // BeastHandlerHotkeyBT
             // 
             this.BeastHandlerHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BeastHandlerHotkeyBT.Location = new System.Drawing.Point(404, 483);
+            this.BeastHandlerHotkeyBT.Location = new System.Drawing.Point(405, 483);
             this.BeastHandlerHotkeyBT.Name = "BeastHandlerHotkeyBT";
-            this.BeastHandlerHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.BeastHandlerHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.BeastHandlerHotkeyBT.TabIndex = 44;
             this.BeastHandlerHotkeyBT.Tag = "34";
             this.BeastHandlerHotkeyBT.Text = "button5";
@@ -2167,7 +2180,7 @@
             // 
             this.label16.AutoSize = true;
             this.label16.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label16.Location = new System.Drawing.Point(279, 40);
+            this.label16.Location = new System.Drawing.Point(280, 40);
             this.label16.Name = "label16";
             this.label16.Size = new System.Drawing.Size(119, 40);
             this.label16.TabIndex = 48;
@@ -2189,7 +2202,7 @@
             // 
             this.label18.AutoSize = true;
             this.label18.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label18.Location = new System.Drawing.Point(279, 80);
+            this.label18.Location = new System.Drawing.Point(280, 80);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(119, 40);
             this.label18.TabIndex = 50;
@@ -2200,7 +2213,7 @@
             // 
             this.label19.AutoSize = true;
             this.label19.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label19.Location = new System.Drawing.Point(279, 120);
+            this.label19.Location = new System.Drawing.Point(280, 120);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(119, 40);
             this.label19.TabIndex = 51;
@@ -2222,7 +2235,7 @@
             // 
             this.label21.AutoSize = true;
             this.label21.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label21.Location = new System.Drawing.Point(279, 160);
+            this.label21.Location = new System.Drawing.Point(280, 160);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(119, 40);
             this.label21.TabIndex = 53;
@@ -2244,7 +2257,7 @@
             // 
             this.label23.AutoSize = true;
             this.label23.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label23.Location = new System.Drawing.Point(279, 200);
+            this.label23.Location = new System.Drawing.Point(280, 200);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(119, 40);
             this.label23.TabIndex = 55;
@@ -2266,7 +2279,7 @@
             // 
             this.label25.AutoSize = true;
             this.label25.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label25.Location = new System.Drawing.Point(279, 240);
+            this.label25.Location = new System.Drawing.Point(280, 240);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(119, 40);
             this.label25.TabIndex = 57;
@@ -2288,7 +2301,7 @@
             // 
             this.label27.AutoSize = true;
             this.label27.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label27.Location = new System.Drawing.Point(279, 280);
+            this.label27.Location = new System.Drawing.Point(280, 280);
             this.label27.Name = "label27";
             this.label27.Size = new System.Drawing.Size(119, 40);
             this.label27.TabIndex = 59;
@@ -2310,7 +2323,7 @@
             // 
             this.label29.AutoSize = true;
             this.label29.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label29.Location = new System.Drawing.Point(279, 320);
+            this.label29.Location = new System.Drawing.Point(280, 320);
             this.label29.Name = "label29";
             this.label29.Size = new System.Drawing.Size(119, 40);
             this.label29.TabIndex = 61;
@@ -2343,7 +2356,7 @@
             // 
             this.label32.AutoSize = true;
             this.label32.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label32.Location = new System.Drawing.Point(279, 360);
+            this.label32.Location = new System.Drawing.Point(280, 360);
             this.label32.Name = "label32";
             this.label32.Size = new System.Drawing.Size(119, 40);
             this.label32.TabIndex = 64;
@@ -2365,7 +2378,7 @@
             // 
             this.label34.AutoSize = true;
             this.label34.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label34.Location = new System.Drawing.Point(279, 400);
+            this.label34.Location = new System.Drawing.Point(280, 400);
             this.label34.Name = "label34";
             this.label34.Size = new System.Drawing.Size(119, 40);
             this.label34.TabIndex = 66;
@@ -2387,7 +2400,7 @@
             // 
             this.label36.AutoSize = true;
             this.label36.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label36.Location = new System.Drawing.Point(279, 440);
+            this.label36.Location = new System.Drawing.Point(280, 440);
             this.label36.Name = "label36";
             this.label36.Size = new System.Drawing.Size(119, 40);
             this.label36.TabIndex = 68;
@@ -2409,7 +2422,7 @@
             // 
             this.label38.AutoSize = true;
             this.label38.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label38.Location = new System.Drawing.Point(279, 480);
+            this.label38.Location = new System.Drawing.Point(280, 480);
             this.label38.Name = "label38";
             this.label38.Size = new System.Drawing.Size(119, 40);
             this.label38.TabIndex = 70;
@@ -2432,7 +2445,7 @@
             this.HeroHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroHotkeyBT.Location = new System.Drawing.Point(128, 563);
             this.HeroHotkeyBT.Name = "HeroHotkeyBT";
-            this.HeroHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroHotkeyBT.TabIndex = 45;
             this.HeroHotkeyBT.Text = "button7";
             this.HeroHotkeyBT.UseVisualStyleBackColor = true;
@@ -2454,7 +2467,7 @@
             this.UpgradeTopPathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.UpgradeTopPathHotkeyBT.Location = new System.Drawing.Point(128, 603);
             this.UpgradeTopPathHotkeyBT.Name = "UpgradeTopPathHotkeyBT";
-            this.UpgradeTopPathHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.UpgradeTopPathHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.UpgradeTopPathHotkeyBT.TabIndex = 46;
             this.UpgradeTopPathHotkeyBT.Text = "button9";
             this.UpgradeTopPathHotkeyBT.UseVisualStyleBackColor = true;
@@ -2464,7 +2477,7 @@
             // 
             this.label42.AutoSize = true;
             this.label42.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label42.Location = new System.Drawing.Point(279, 600);
+            this.label42.Location = new System.Drawing.Point(280, 600);
             this.label42.Name = "label42";
             this.label42.Size = new System.Drawing.Size(119, 40);
             this.label42.TabIndex = 73;
@@ -2497,7 +2510,7 @@
             // 
             this.label45.AutoSize = true;
             this.label45.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label45.Location = new System.Drawing.Point(279, 680);
+            this.label45.Location = new System.Drawing.Point(280, 680);
             this.label45.Name = "label45";
             this.label45.Size = new System.Drawing.Size(119, 40);
             this.label45.TabIndex = 76;
@@ -2519,7 +2532,7 @@
             // 
             this.label47.AutoSize = true;
             this.label47.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label47.Location = new System.Drawing.Point(279, 720);
+            this.label47.Location = new System.Drawing.Point(280, 720);
             this.label47.Name = "label47";
             this.label47.Size = new System.Drawing.Size(119, 40);
             this.label47.TabIndex = 78;
@@ -2542,7 +2555,7 @@
             this.UpgradeBottomPathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.UpgradeBottomPathHotkeyBT.Location = new System.Drawing.Point(128, 643);
             this.UpgradeBottomPathHotkeyBT.Name = "UpgradeBottomPathHotkeyBT";
-            this.UpgradeBottomPathHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.UpgradeBottomPathHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.UpgradeBottomPathHotkeyBT.TabIndex = 91;
             this.UpgradeBottomPathHotkeyBT.Text = "button1";
             this.UpgradeBottomPathHotkeyBT.UseVisualStyleBackColor = true;
@@ -2553,7 +2566,7 @@
             this.SwitchTargetHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SwitchTargetHotkeyBT.Location = new System.Drawing.Point(128, 683);
             this.SwitchTargetHotkeyBT.Name = "SwitchTargetHotkeyBT";
-            this.SwitchTargetHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.SwitchTargetHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.SwitchTargetHotkeyBT.TabIndex = 92;
             this.SwitchTargetHotkeyBT.Text = "button2";
             this.SwitchTargetHotkeyBT.UseVisualStyleBackColor = true;
@@ -2564,7 +2577,7 @@
             this.SetFunction1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SetFunction1HotkeyBT.Location = new System.Drawing.Point(128, 723);
             this.SetFunction1HotkeyBT.Name = "SetFunction1HotkeyBT";
-            this.SetFunction1HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.SetFunction1HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.SetFunction1HotkeyBT.TabIndex = 93;
             this.SetFunction1HotkeyBT.Text = "button3";
             this.SetFunction1HotkeyBT.UseVisualStyleBackColor = true;
@@ -2575,7 +2588,7 @@
             this.NextRoundHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.NextRoundHotkeyBT.Location = new System.Drawing.Point(128, 763);
             this.NextRoundHotkeyBT.Name = "NextRoundHotkeyBT";
-            this.NextRoundHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.NextRoundHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.NextRoundHotkeyBT.TabIndex = 94;
             this.NextRoundHotkeyBT.Text = "button4";
             this.NextRoundHotkeyBT.UseVisualStyleBackColor = true;
@@ -2584,9 +2597,9 @@
             // UpgradeMiddlePathHotkeyBT
             // 
             this.UpgradeMiddlePathHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.UpgradeMiddlePathHotkeyBT.Location = new System.Drawing.Point(404, 603);
+            this.UpgradeMiddlePathHotkeyBT.Location = new System.Drawing.Point(405, 603);
             this.UpgradeMiddlePathHotkeyBT.Name = "UpgradeMiddlePathHotkeyBT";
-            this.UpgradeMiddlePathHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.UpgradeMiddlePathHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.UpgradeMiddlePathHotkeyBT.TabIndex = 99;
             this.UpgradeMiddlePathHotkeyBT.Text = "button9";
             this.UpgradeMiddlePathHotkeyBT.UseVisualStyleBackColor = true;
@@ -2595,9 +2608,9 @@
             // ReverseSwitchTargetHotkeyBT
             // 
             this.ReverseSwitchTargetHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReverseSwitchTargetHotkeyBT.Location = new System.Drawing.Point(404, 683);
+            this.ReverseSwitchTargetHotkeyBT.Location = new System.Drawing.Point(405, 683);
             this.ReverseSwitchTargetHotkeyBT.Name = "ReverseSwitchTargetHotkeyBT";
-            this.ReverseSwitchTargetHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.ReverseSwitchTargetHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.ReverseSwitchTargetHotkeyBT.TabIndex = 100;
             this.ReverseSwitchTargetHotkeyBT.Text = "button10";
             this.ReverseSwitchTargetHotkeyBT.UseVisualStyleBackColor = true;
@@ -2606,9 +2619,9 @@
             // SetFunction2HotkeyBT
             // 
             this.SetFunction2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SetFunction2HotkeyBT.Location = new System.Drawing.Point(404, 723);
+            this.SetFunction2HotkeyBT.Location = new System.Drawing.Point(405, 723);
             this.SetFunction2HotkeyBT.Name = "SetFunction2HotkeyBT";
-            this.SetFunction2HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.SetFunction2HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.SetFunction2HotkeyBT.TabIndex = 101;
             this.SetFunction2HotkeyBT.Text = "button11";
             this.SetFunction2HotkeyBT.UseVisualStyleBackColor = true;
@@ -2630,7 +2643,7 @@
             this.Skill11HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill11HotkeyBT.Location = new System.Drawing.Point(128, 1003);
             this.Skill11HotkeyBT.Name = "Skill11HotkeyBT";
-            this.Skill11HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill11HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill11HotkeyBT.TabIndex = 108;
             this.Skill11HotkeyBT.Text = "button18";
             this.Skill11HotkeyBT.UseVisualStyleBackColor = true;
@@ -2639,9 +2652,9 @@
             // Skill10HotkeyBT
             // 
             this.Skill10HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill10HotkeyBT.Location = new System.Drawing.Point(404, 963);
+            this.Skill10HotkeyBT.Location = new System.Drawing.Point(405, 963);
             this.Skill10HotkeyBT.Name = "Skill10HotkeyBT";
-            this.Skill10HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill10HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill10HotkeyBT.TabIndex = 107;
             this.Skill10HotkeyBT.Text = "button17";
             this.Skill10HotkeyBT.UseVisualStyleBackColor = true;
@@ -2651,7 +2664,7 @@
             // 
             this.label58.AutoSize = true;
             this.label58.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label58.Location = new System.Drawing.Point(279, 960);
+            this.label58.Location = new System.Drawing.Point(280, 960);
             this.label58.Name = "label58";
             this.label58.Size = new System.Drawing.Size(119, 40);
             this.label58.TabIndex = 89;
@@ -2674,7 +2687,7 @@
             this.Skill9HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill9HotkeyBT.Location = new System.Drawing.Point(128, 963);
             this.Skill9HotkeyBT.Name = "Skill9HotkeyBT";
-            this.Skill9HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill9HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill9HotkeyBT.TabIndex = 106;
             this.Skill9HotkeyBT.Text = "button16";
             this.Skill9HotkeyBT.UseVisualStyleBackColor = true;
@@ -2683,9 +2696,9 @@
             // Skill8HotkeyBT
             // 
             this.Skill8HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill8HotkeyBT.Location = new System.Drawing.Point(404, 923);
+            this.Skill8HotkeyBT.Location = new System.Drawing.Point(405, 923);
             this.Skill8HotkeyBT.Name = "Skill8HotkeyBT";
-            this.Skill8HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill8HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill8HotkeyBT.TabIndex = 98;
             this.Skill8HotkeyBT.Text = "button8";
             this.Skill8HotkeyBT.UseVisualStyleBackColor = true;
@@ -2695,7 +2708,7 @@
             // 
             this.label56.AutoSize = true;
             this.label56.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label56.Location = new System.Drawing.Point(279, 920);
+            this.label56.Location = new System.Drawing.Point(280, 920);
             this.label56.Name = "label56";
             this.label56.Size = new System.Drawing.Size(119, 40);
             this.label56.TabIndex = 87;
@@ -2718,7 +2731,7 @@
             this.Skill7HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill7HotkeyBT.Location = new System.Drawing.Point(128, 923);
             this.Skill7HotkeyBT.Name = "Skill7HotkeyBT";
-            this.Skill7HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill7HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill7HotkeyBT.TabIndex = 105;
             this.Skill7HotkeyBT.Text = "button15";
             this.Skill7HotkeyBT.UseVisualStyleBackColor = true;
@@ -2727,9 +2740,9 @@
             // Skill6HotkeyBT
             // 
             this.Skill6HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill6HotkeyBT.Location = new System.Drawing.Point(404, 883);
+            this.Skill6HotkeyBT.Location = new System.Drawing.Point(405, 883);
             this.Skill6HotkeyBT.Name = "Skill6HotkeyBT";
-            this.Skill6HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill6HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill6HotkeyBT.TabIndex = 97;
             this.Skill6HotkeyBT.Text = "button7";
             this.Skill6HotkeyBT.UseVisualStyleBackColor = true;
@@ -2739,7 +2752,7 @@
             // 
             this.label54.AutoSize = true;
             this.label54.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label54.Location = new System.Drawing.Point(279, 880);
+            this.label54.Location = new System.Drawing.Point(280, 880);
             this.label54.Name = "label54";
             this.label54.Size = new System.Drawing.Size(119, 40);
             this.label54.TabIndex = 85;
@@ -2762,7 +2775,7 @@
             this.Skill5HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill5HotkeyBT.Location = new System.Drawing.Point(128, 883);
             this.Skill5HotkeyBT.Name = "Skill5HotkeyBT";
-            this.Skill5HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill5HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill5HotkeyBT.TabIndex = 104;
             this.Skill5HotkeyBT.Text = "button14";
             this.Skill5HotkeyBT.UseVisualStyleBackColor = true;
@@ -2771,9 +2784,9 @@
             // Skill4HotkeyBT
             // 
             this.Skill4HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill4HotkeyBT.Location = new System.Drawing.Point(404, 843);
+            this.Skill4HotkeyBT.Location = new System.Drawing.Point(405, 843);
             this.Skill4HotkeyBT.Name = "Skill4HotkeyBT";
-            this.Skill4HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill4HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill4HotkeyBT.TabIndex = 96;
             this.Skill4HotkeyBT.Text = "button6";
             this.Skill4HotkeyBT.UseVisualStyleBackColor = true;
@@ -2783,7 +2796,7 @@
             // 
             this.label52.AutoSize = true;
             this.label52.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label52.Location = new System.Drawing.Point(279, 840);
+            this.label52.Location = new System.Drawing.Point(280, 840);
             this.label52.Name = "label52";
             this.label52.Size = new System.Drawing.Size(119, 40);
             this.label52.TabIndex = 83;
@@ -2806,7 +2819,7 @@
             this.Skill3HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill3HotkeyBT.Location = new System.Drawing.Point(128, 843);
             this.Skill3HotkeyBT.Name = "Skill3HotkeyBT";
-            this.Skill3HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill3HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill3HotkeyBT.TabIndex = 103;
             this.Skill3HotkeyBT.Text = "button13";
             this.Skill3HotkeyBT.UseVisualStyleBackColor = true;
@@ -2815,9 +2828,9 @@
             // Skill2HotkeyBT
             // 
             this.Skill2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill2HotkeyBT.Location = new System.Drawing.Point(404, 803);
+            this.Skill2HotkeyBT.Location = new System.Drawing.Point(405, 803);
             this.Skill2HotkeyBT.Name = "Skill2HotkeyBT";
-            this.Skill2HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill2HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill2HotkeyBT.TabIndex = 95;
             this.Skill2HotkeyBT.Text = "button5";
             this.Skill2HotkeyBT.UseVisualStyleBackColor = true;
@@ -2827,7 +2840,7 @@
             // 
             this.label50.AutoSize = true;
             this.label50.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label50.Location = new System.Drawing.Point(279, 800);
+            this.label50.Location = new System.Drawing.Point(280, 800);
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(119, 40);
             this.label50.TabIndex = 81;
@@ -2850,7 +2863,7 @@
             this.Skill1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Skill1HotkeyBT.Location = new System.Drawing.Point(128, 803);
             this.Skill1HotkeyBT.Name = "Skill1HotkeyBT";
-            this.Skill1HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.Skill1HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.Skill1HotkeyBT.TabIndex = 102;
             this.Skill1HotkeyBT.Text = "button12";
             this.Skill1HotkeyBT.UseVisualStyleBackColor = true;
@@ -2860,7 +2873,7 @@
             // 
             this.label60.AutoSize = true;
             this.label60.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label60.Location = new System.Drawing.Point(279, 1000);
+            this.label60.Location = new System.Drawing.Point(280, 1000);
             this.label60.Name = "label60";
             this.label60.Size = new System.Drawing.Size(119, 40);
             this.label60.TabIndex = 109;
@@ -2870,9 +2883,9 @@
             // Skill12HotkeyBT
             // 
             this.Skill12HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Skill12HotkeyBT.Location = new System.Drawing.Point(404, 1003);
+            this.Skill12HotkeyBT.Location = new System.Drawing.Point(405, 1003);
             this.Skill12HotkeyBT.Name = "Skill12HotkeyBT";
-            this.Skill12HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.Skill12HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.Skill12HotkeyBT.TabIndex = 110;
             this.Skill12HotkeyBT.Text = "button1";
             this.Skill12HotkeyBT.UseVisualStyleBackColor = true;
@@ -2882,7 +2895,7 @@
             // 
             this.label61.AutoSize = true;
             this.label61.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label61.Location = new System.Drawing.Point(279, 760);
+            this.label61.Location = new System.Drawing.Point(280, 760);
             this.label61.Name = "label61";
             this.label61.Size = new System.Drawing.Size(119, 40);
             this.label61.TabIndex = 111;
@@ -2892,9 +2905,9 @@
             // ChangeSpeedHotkeyBT
             // 
             this.ChangeSpeedHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ChangeSpeedHotkeyBT.Location = new System.Drawing.Point(404, 763);
+            this.ChangeSpeedHotkeyBT.Location = new System.Drawing.Point(405, 763);
             this.ChangeSpeedHotkeyBT.Name = "ChangeSpeedHotkeyBT";
-            this.ChangeSpeedHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.ChangeSpeedHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.ChangeSpeedHotkeyBT.TabIndex = 112;
             this.ChangeSpeedHotkeyBT.Text = "button1";
             this.ChangeSpeedHotkeyBT.UseVisualStyleBackColor = true;
@@ -3002,7 +3015,7 @@
             // 
             this.label70.AutoSize = true;
             this.label70.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label70.Location = new System.Drawing.Point(279, 1040);
+            this.label70.Location = new System.Drawing.Point(280, 1040);
             this.label70.Name = "label70";
             this.label70.Size = new System.Drawing.Size(119, 40);
             this.label70.TabIndex = 122;
@@ -3013,7 +3026,7 @@
             // 
             this.label71.AutoSize = true;
             this.label71.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label71.Location = new System.Drawing.Point(279, 1080);
+            this.label71.Location = new System.Drawing.Point(280, 1080);
             this.label71.Name = "label71";
             this.label71.Size = new System.Drawing.Size(119, 40);
             this.label71.TabIndex = 123;
@@ -3024,7 +3037,7 @@
             // 
             this.label72.AutoSize = true;
             this.label72.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label72.Location = new System.Drawing.Point(279, 1120);
+            this.label72.Location = new System.Drawing.Point(280, 1120);
             this.label72.Name = "label72";
             this.label72.Size = new System.Drawing.Size(119, 40);
             this.label72.TabIndex = 124;
@@ -3035,7 +3048,7 @@
             // 
             this.label73.AutoSize = true;
             this.label73.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label73.Location = new System.Drawing.Point(279, 1160);
+            this.label73.Location = new System.Drawing.Point(280, 1160);
             this.label73.Name = "label73";
             this.label73.Size = new System.Drawing.Size(119, 40);
             this.label73.TabIndex = 125;
@@ -3046,7 +3059,7 @@
             // 
             this.label74.AutoSize = true;
             this.label74.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label74.Location = new System.Drawing.Point(279, 1200);
+            this.label74.Location = new System.Drawing.Point(280, 1200);
             this.label74.Name = "label74";
             this.label74.Size = new System.Drawing.Size(119, 40);
             this.label74.TabIndex = 126;
@@ -3057,7 +3070,7 @@
             // 
             this.label75.AutoSize = true;
             this.label75.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label75.Location = new System.Drawing.Point(279, 1240);
+            this.label75.Location = new System.Drawing.Point(280, 1240);
             this.label75.Name = "label75";
             this.label75.Size = new System.Drawing.Size(119, 40);
             this.label75.TabIndex = 127;
@@ -3068,7 +3081,7 @@
             // 
             this.label76.AutoSize = true;
             this.label76.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label76.Location = new System.Drawing.Point(279, 1280);
+            this.label76.Location = new System.Drawing.Point(280, 1280);
             this.label76.Name = "label76";
             this.label76.Size = new System.Drawing.Size(119, 40);
             this.label76.TabIndex = 128;
@@ -3079,7 +3092,7 @@
             // 
             this.label77.AutoSize = true;
             this.label77.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label77.Location = new System.Drawing.Point(279, 1320);
+            this.label77.Location = new System.Drawing.Point(280, 1320);
             this.label77.Name = "label77";
             this.label77.Size = new System.Drawing.Size(119, 40);
             this.label77.TabIndex = 129;
@@ -3091,7 +3104,7 @@
             this.HeroObject1HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject1HotkeyBT.Location = new System.Drawing.Point(128, 1043);
             this.HeroObject1HotkeyBT.Name = "HeroObject1HotkeyBT";
-            this.HeroObject1HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject1HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject1HotkeyBT.TabIndex = 130;
             this.HeroObject1HotkeyBT.Text = "button1";
             this.HeroObject1HotkeyBT.UseVisualStyleBackColor = true;
@@ -3100,9 +3113,9 @@
             // HeroObject2HotkeyBT
             // 
             this.HeroObject2HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject2HotkeyBT.Location = new System.Drawing.Point(404, 1043);
+            this.HeroObject2HotkeyBT.Location = new System.Drawing.Point(405, 1043);
             this.HeroObject2HotkeyBT.Name = "HeroObject2HotkeyBT";
-            this.HeroObject2HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject2HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject2HotkeyBT.TabIndex = 131;
             this.HeroObject2HotkeyBT.Text = "button2";
             this.HeroObject2HotkeyBT.UseVisualStyleBackColor = true;
@@ -3113,7 +3126,7 @@
             this.HeroObject3HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject3HotkeyBT.Location = new System.Drawing.Point(128, 1083);
             this.HeroObject3HotkeyBT.Name = "HeroObject3HotkeyBT";
-            this.HeroObject3HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject3HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject3HotkeyBT.TabIndex = 132;
             this.HeroObject3HotkeyBT.Text = "button3";
             this.HeroObject3HotkeyBT.UseVisualStyleBackColor = true;
@@ -3122,9 +3135,9 @@
             // HeroObject4HotkeyBT
             // 
             this.HeroObject4HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject4HotkeyBT.Location = new System.Drawing.Point(404, 1083);
+            this.HeroObject4HotkeyBT.Location = new System.Drawing.Point(405, 1083);
             this.HeroObject4HotkeyBT.Name = "HeroObject4HotkeyBT";
-            this.HeroObject4HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject4HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject4HotkeyBT.TabIndex = 133;
             this.HeroObject4HotkeyBT.Text = "button4";
             this.HeroObject4HotkeyBT.UseVisualStyleBackColor = true;
@@ -3135,7 +3148,7 @@
             this.HeroObject5HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject5HotkeyBT.Location = new System.Drawing.Point(128, 1123);
             this.HeroObject5HotkeyBT.Name = "HeroObject5HotkeyBT";
-            this.HeroObject5HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject5HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject5HotkeyBT.TabIndex = 134;
             this.HeroObject5HotkeyBT.Text = "button5";
             this.HeroObject5HotkeyBT.UseVisualStyleBackColor = true;
@@ -3144,9 +3157,9 @@
             // HeroObject6HotkeyBT
             // 
             this.HeroObject6HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject6HotkeyBT.Location = new System.Drawing.Point(404, 1123);
+            this.HeroObject6HotkeyBT.Location = new System.Drawing.Point(405, 1123);
             this.HeroObject6HotkeyBT.Name = "HeroObject6HotkeyBT";
-            this.HeroObject6HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject6HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject6HotkeyBT.TabIndex = 135;
             this.HeroObject6HotkeyBT.Text = "button6";
             this.HeroObject6HotkeyBT.UseVisualStyleBackColor = true;
@@ -3157,7 +3170,7 @@
             this.HeroObject7HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject7HotkeyBT.Location = new System.Drawing.Point(128, 1163);
             this.HeroObject7HotkeyBT.Name = "HeroObject7HotkeyBT";
-            this.HeroObject7HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject7HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject7HotkeyBT.TabIndex = 136;
             this.HeroObject7HotkeyBT.Text = "button7";
             this.HeroObject7HotkeyBT.UseVisualStyleBackColor = true;
@@ -3166,9 +3179,9 @@
             // HeroObject8HotkeyBT
             // 
             this.HeroObject8HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject8HotkeyBT.Location = new System.Drawing.Point(404, 1163);
+            this.HeroObject8HotkeyBT.Location = new System.Drawing.Point(405, 1163);
             this.HeroObject8HotkeyBT.Name = "HeroObject8HotkeyBT";
-            this.HeroObject8HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject8HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject8HotkeyBT.TabIndex = 137;
             this.HeroObject8HotkeyBT.Text = "button8";
             this.HeroObject8HotkeyBT.UseVisualStyleBackColor = true;
@@ -3179,7 +3192,7 @@
             this.HeroObject9HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject9HotkeyBT.Location = new System.Drawing.Point(128, 1203);
             this.HeroObject9HotkeyBT.Name = "HeroObject9HotkeyBT";
-            this.HeroObject9HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject9HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject9HotkeyBT.TabIndex = 138;
             this.HeroObject9HotkeyBT.Text = "button9";
             this.HeroObject9HotkeyBT.UseVisualStyleBackColor = true;
@@ -3188,9 +3201,9 @@
             // HeroObject10HotkeyBT
             // 
             this.HeroObject10HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject10HotkeyBT.Location = new System.Drawing.Point(404, 1203);
+            this.HeroObject10HotkeyBT.Location = new System.Drawing.Point(405, 1203);
             this.HeroObject10HotkeyBT.Name = "HeroObject10HotkeyBT";
-            this.HeroObject10HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject10HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject10HotkeyBT.TabIndex = 139;
             this.HeroObject10HotkeyBT.Text = "button10";
             this.HeroObject10HotkeyBT.UseVisualStyleBackColor = true;
@@ -3201,7 +3214,7 @@
             this.HeroObject11HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject11HotkeyBT.Location = new System.Drawing.Point(128, 1243);
             this.HeroObject11HotkeyBT.Name = "HeroObject11HotkeyBT";
-            this.HeroObject11HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject11HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject11HotkeyBT.TabIndex = 140;
             this.HeroObject11HotkeyBT.Text = "button11";
             this.HeroObject11HotkeyBT.UseVisualStyleBackColor = true;
@@ -3210,9 +3223,9 @@
             // HeroObject12HotkeyBT
             // 
             this.HeroObject12HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject12HotkeyBT.Location = new System.Drawing.Point(404, 1243);
+            this.HeroObject12HotkeyBT.Location = new System.Drawing.Point(405, 1243);
             this.HeroObject12HotkeyBT.Name = "HeroObject12HotkeyBT";
-            this.HeroObject12HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject12HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject12HotkeyBT.TabIndex = 141;
             this.HeroObject12HotkeyBT.Text = "button12";
             this.HeroObject12HotkeyBT.UseVisualStyleBackColor = true;
@@ -3223,7 +3236,7 @@
             this.HeroObject13HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject13HotkeyBT.Location = new System.Drawing.Point(128, 1283);
             this.HeroObject13HotkeyBT.Name = "HeroObject13HotkeyBT";
-            this.HeroObject13HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject13HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject13HotkeyBT.TabIndex = 142;
             this.HeroObject13HotkeyBT.Text = "button13";
             this.HeroObject13HotkeyBT.UseVisualStyleBackColor = true;
@@ -3232,9 +3245,9 @@
             // HeroObject14HotkeyBT
             // 
             this.HeroObject14HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject14HotkeyBT.Location = new System.Drawing.Point(404, 1283);
+            this.HeroObject14HotkeyBT.Location = new System.Drawing.Point(405, 1283);
             this.HeroObject14HotkeyBT.Name = "HeroObject14HotkeyBT";
-            this.HeroObject14HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject14HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject14HotkeyBT.TabIndex = 143;
             this.HeroObject14HotkeyBT.Text = "button14";
             this.HeroObject14HotkeyBT.UseVisualStyleBackColor = true;
@@ -3245,7 +3258,7 @@
             this.HeroObject15HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HeroObject15HotkeyBT.Location = new System.Drawing.Point(128, 1323);
             this.HeroObject15HotkeyBT.Name = "HeroObject15HotkeyBT";
-            this.HeroObject15HotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.HeroObject15HotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.HeroObject15HotkeyBT.TabIndex = 144;
             this.HeroObject15HotkeyBT.Text = "button15";
             this.HeroObject15HotkeyBT.UseVisualStyleBackColor = true;
@@ -3254,9 +3267,9 @@
             // HeroObject16HotkeyBT
             // 
             this.HeroObject16HotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HeroObject16HotkeyBT.Location = new System.Drawing.Point(404, 1323);
+            this.HeroObject16HotkeyBT.Location = new System.Drawing.Point(405, 1323);
             this.HeroObject16HotkeyBT.Name = "HeroObject16HotkeyBT";
-            this.HeroObject16HotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.HeroObject16HotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.HeroObject16HotkeyBT.TabIndex = 145;
             this.HeroObject16HotkeyBT.Text = "button16";
             this.HeroObject16HotkeyBT.UseVisualStyleBackColor = true;
@@ -3266,7 +3279,7 @@
             // 
             this.label78.AutoSize = true;
             this.label78.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label78.Location = new System.Drawing.Point(279, 640);
+            this.label78.Location = new System.Drawing.Point(280, 640);
             this.label78.Name = "label78";
             this.label78.Size = new System.Drawing.Size(119, 40);
             this.label78.TabIndex = 146;
@@ -3276,9 +3289,9 @@
             // SellHotkeyBT
             // 
             this.SellHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SellHotkeyBT.Location = new System.Drawing.Point(404, 643);
+            this.SellHotkeyBT.Location = new System.Drawing.Point(405, 643);
             this.SellHotkeyBT.Name = "SellHotkeyBT";
-            this.SellHotkeyBT.Size = new System.Drawing.Size(146, 34);
+            this.SellHotkeyBT.Size = new System.Drawing.Size(147, 34);
             this.SellHotkeyBT.TabIndex = 147;
             this.SellHotkeyBT.Text = "button1";
             this.SellHotkeyBT.UseVisualStyleBackColor = true;
@@ -3301,7 +3314,7 @@
             this.DesperadoHotkeyBT.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DesperadoHotkeyBT.Location = new System.Drawing.Point(128, 523);
             this.DesperadoHotkeyBT.Name = "DesperadoHotkeyBT";
-            this.DesperadoHotkeyBT.Size = new System.Drawing.Size(145, 34);
+            this.DesperadoHotkeyBT.Size = new System.Drawing.Size(146, 34);
             this.DesperadoHotkeyBT.TabIndex = 149;
             this.DesperadoHotkeyBT.Tag = "6";
             this.DesperadoHotkeyBT.Text = "button1";
@@ -3349,13 +3362,13 @@
             this.tableLayoutPanel11.Name = "tableLayoutPanel11";
             this.tableLayoutPanel11.RowCount = 1;
             this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.Size = new System.Drawing.Size(553, 39);
+            this.tableLayoutPanel11.Size = new System.Drawing.Size(555, 39);
             this.tableLayoutPanel11.TabIndex = 7;
             // 
             // AddBundleBT
             // 
             this.AddBundleBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AddBundleBT.Location = new System.Drawing.Point(356, 3);
+            this.AddBundleBT.Location = new System.Drawing.Point(358, 3);
             this.AddBundleBT.Name = "AddBundleBT";
             this.AddBundleBT.Size = new System.Drawing.Size(74, 33);
             this.AddBundleBT.TabIndex = 0;
@@ -3366,7 +3379,7 @@
             // DeleteBundleBT
             // 
             this.DeleteBundleBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DeleteBundleBT.Location = new System.Drawing.Point(456, 3);
+            this.DeleteBundleBT.Location = new System.Drawing.Point(458, 3);
             this.DeleteBundleBT.Name = "DeleteBundleBT";
             this.DeleteBundleBT.Size = new System.Drawing.Size(74, 33);
             this.DeleteBundleBT.TabIndex = 1;
@@ -3382,7 +3395,7 @@
             this.BundleNamesCB.FormattingEnabled = true;
             this.BundleNamesCB.Location = new System.Drawing.Point(3, 3);
             this.BundleNamesCB.Name = "BundleNamesCB";
-            this.BundleNamesCB.Size = new System.Drawing.Size(247, 28);
+            this.BundleNamesCB.Size = new System.Drawing.Size(249, 35);
             this.BundleNamesCB.TabIndex = 2;
             // 
             // label82
@@ -3412,13 +3425,13 @@
             this.tableLayoutPanel21.Name = "tableLayoutPanel21";
             this.tableLayoutPanel21.RowCount = 1;
             this.tableLayoutPanel21.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel21.Size = new System.Drawing.Size(553, 39);
+            this.tableLayoutPanel21.Size = new System.Drawing.Size(555, 39);
             this.tableLayoutPanel21.TabIndex = 9;
             // 
             // CheckUpdateBT
             // 
             this.CheckUpdateBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CheckUpdateBT.Location = new System.Drawing.Point(356, 3);
+            this.CheckUpdateBT.Location = new System.Drawing.Point(358, 3);
             this.CheckUpdateBT.Name = "CheckUpdateBT";
             this.CheckUpdateBT.Size = new System.Drawing.Size(114, 33);
             this.CheckUpdateBT.TabIndex = 0;
@@ -3432,7 +3445,7 @@
             this.VersionLB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.VersionLB.Location = new System.Drawing.Point(3, 0);
             this.VersionLB.Name = "VersionLB";
-            this.VersionLB.Size = new System.Drawing.Size(247, 39);
+            this.VersionLB.Size = new System.Drawing.Size(249, 39);
             this.VersionLB.TabIndex = 1;
             this.VersionLB.Text = "当前版本：";
             this.VersionLB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -3449,7 +3462,7 @@
             this.tableLayoutPanel24.Name = "tableLayoutPanel24";
             this.tableLayoutPanel24.RowCount = 1;
             this.tableLayoutPanel24.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel24.Size = new System.Drawing.Size(553, 44);
+            this.tableLayoutPanel24.Size = new System.Drawing.Size(555, 44);
             this.tableLayoutPanel24.TabIndex = 10;
             // 
             // EnableLoggingCB
@@ -3460,7 +3473,7 @@
             this.EnableLoggingCB.Dock = System.Windows.Forms.DockStyle.Fill;
             this.EnableLoggingCB.Location = new System.Drawing.Point(3, 3);
             this.EnableLoggingCB.Name = "EnableLoggingCB";
-            this.EnableLoggingCB.Size = new System.Drawing.Size(270, 38);
+            this.EnableLoggingCB.Size = new System.Drawing.Size(271, 38);
             this.EnableLoggingCB.TabIndex = 0;
             this.EnableLoggingCB.Text = "启用日志输出";
             this.EnableLoggingCB.UseVisualStyleBackColor = true;
@@ -3470,9 +3483,9 @@
             // 
             this.EnableMaskWindowCB.AutoSize = true;
             this.EnableMaskWindowCB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.EnableMaskWindowCB.Location = new System.Drawing.Point(279, 3);
+            this.EnableMaskWindowCB.Location = new System.Drawing.Point(280, 3);
             this.EnableMaskWindowCB.Name = "EnableMaskWindowCB";
-            this.EnableMaskWindowCB.Size = new System.Drawing.Size(271, 38);
+            this.EnableMaskWindowCB.Size = new System.Drawing.Size(272, 38);
             this.EnableMaskWindowCB.TabIndex = 1;
             this.EnableMaskWindowCB.Text = "读屏标记";
             this.EnableMaskWindowCB.UseVisualStyleBackColor = true;
@@ -3521,7 +3534,7 @@
             this.tableLayoutPanel14.ColumnCount = 3;
             this.tableLayoutPanel14.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45.49356F));
             this.tableLayoutPanel14.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 54.50644F));
-            this.tableLayoutPanel14.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 222F));
+            this.tableLayoutPanel14.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 226F));
             this.tableLayoutPanel14.Controls.Add(this.OperationsTV, 0, 0);
             this.tableLayoutPanel14.Controls.Add(this.tableLayoutPanel15, 2, 0);
             this.tableLayoutPanel14.Controls.Add(this.OperationsLV, 1, 0);
@@ -3540,7 +3553,7 @@
             this.OperationsTV.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OperationsTV.Location = new System.Drawing.Point(3, 3);
             this.OperationsTV.Name = "OperationsTV";
-            this.OperationsTV.Size = new System.Drawing.Size(206, 627);
+            this.OperationsTV.Size = new System.Drawing.Size(204, 627);
             this.OperationsTV.TabIndex = 0;
             this.OperationsTV.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OperationsTV_AfterSelect);
             // 
@@ -3555,25 +3568,25 @@
             this.tableLayoutPanel15.Controls.Add(this.OutputBT, 0, 4);
             this.tableLayoutPanel15.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.tableLayoutPanel15.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel15.Location = new System.Drawing.Point(469, 3);
+            this.tableLayoutPanel15.Location = new System.Drawing.Point(464, 3);
             this.tableLayoutPanel15.Name = "tableLayoutPanel15";
             this.tableLayoutPanel15.RowCount = 7;
             this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 66.66666F));
             this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel15.Size = new System.Drawing.Size(216, 627);
+            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel15.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel15.Size = new System.Drawing.Size(221, 627);
             this.tableLayoutPanel15.TabIndex = 1;
             // 
             // ImportBT
             // 
             this.ImportBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ImportBT.Location = new System.Drawing.Point(3, 489);
+            this.ImportBT.Location = new System.Drawing.Point(3, 469);
             this.ImportBT.Name = "ImportBT";
-            this.ImportBT.Size = new System.Drawing.Size(210, 29);
+            this.ImportBT.Size = new System.Drawing.Size(215, 34);
             this.ImportBT.TabIndex = 0;
             this.ImportBT.Text = "导入";
             this.ImportBT.UseVisualStyleBackColor = true;
@@ -3582,9 +3595,9 @@
             // EditBT
             // 
             this.EditBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.EditBT.Location = new System.Drawing.Point(3, 559);
+            this.EditBT.Location = new System.Drawing.Point(3, 549);
             this.EditBT.Name = "EditBT";
-            this.EditBT.Size = new System.Drawing.Size(210, 29);
+            this.EditBT.Size = new System.Drawing.Size(215, 34);
             this.EditBT.TabIndex = 1;
             this.EditBT.Text = "编辑";
             this.EditBT.UseVisualStyleBackColor = true;
@@ -3593,9 +3606,9 @@
             // RunBT
             // 
             this.RunBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RunBT.Location = new System.Drawing.Point(3, 594);
+            this.RunBT.Location = new System.Drawing.Point(3, 589);
             this.RunBT.Name = "RunBT";
-            this.RunBT.Size = new System.Drawing.Size(210, 30);
+            this.RunBT.Size = new System.Drawing.Size(215, 35);
             this.RunBT.TabIndex = 2;
             this.RunBT.Text = "运行";
             this.RunBT.UseVisualStyleBackColor = true;
@@ -3604,9 +3617,9 @@
             // DeleteOperationBT
             // 
             this.DeleteOperationBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DeleteOperationBT.Location = new System.Drawing.Point(3, 454);
+            this.DeleteOperationBT.Location = new System.Drawing.Point(3, 429);
             this.DeleteOperationBT.Name = "DeleteOperationBT";
-            this.DeleteOperationBT.Size = new System.Drawing.Size(210, 29);
+            this.DeleteOperationBT.Size = new System.Drawing.Size(215, 34);
             this.DeleteOperationBT.TabIndex = 3;
             this.DeleteOperationBT.Text = "删除";
             this.DeleteOperationBT.UseVisualStyleBackColor = true;
@@ -3615,9 +3628,9 @@
             // OutputBT
             // 
             this.OutputBT.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.OutputBT.Location = new System.Drawing.Point(3, 524);
+            this.OutputBT.Location = new System.Drawing.Point(3, 509);
             this.OutputBT.Name = "OutputBT";
-            this.OutputBT.Size = new System.Drawing.Size(210, 29);
+            this.OutputBT.Size = new System.Drawing.Size(215, 34);
             this.OutputBT.TabIndex = 4;
             this.OutputBT.Text = "导出";
             this.OutputBT.UseVisualStyleBackColor = true;
@@ -3632,9 +3645,9 @@
             this.OperationsLV.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OperationsLV.HideSelection = false;
             this.OperationsLV.LabelEdit = true;
-            this.OperationsLV.Location = new System.Drawing.Point(215, 3);
+            this.OperationsLV.Location = new System.Drawing.Point(213, 3);
             this.OperationsLV.Name = "OperationsLV";
-            this.OperationsLV.Size = new System.Drawing.Size(248, 627);
+            this.OperationsLV.Size = new System.Drawing.Size(245, 627);
             this.OperationsLV.TabIndex = 2;
             this.OperationsLV.UseCompatibleStateImageBehavior = false;
             this.OperationsLV.View = System.Windows.Forms.View.Details;
@@ -3669,13 +3682,13 @@
             this.tabPage1.ResumeLayout(false);
             this.panel1.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
             this.tableLayoutPanel7.ResumeLayout(false);
+            this.tableLayoutPanel25.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.tableLayoutPanel5.ResumeLayout(false);
             this.tableLayoutPanel5.PerformLayout();
@@ -3788,9 +3801,7 @@
         private System.Windows.Forms.Button SaveSettingsBT;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.GroupBox groupBox2;
-        private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Label label10;
-        private System.Windows.Forms.Label label11;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel17;
         private System.Windows.Forms.Button SpikeFactoryHotkeyBT;
@@ -3984,6 +3995,8 @@
         private System.Windows.Forms.Label VersionLB;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel24;
         private System.Windows.Forms.CheckBox EnableMaskWindowCB;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel25;
+        private System.Windows.Forms.Button PauseBT;
     }
 }
 

--- a/BTD6AutoCommunity/Views/Main/Form1.cs
+++ b/BTD6AutoCommunity/Views/Main/Form1.cs
@@ -83,7 +83,7 @@ namespace BTD6AutoCommunity.Views.Main
         private void BTD6AutoCommunity_FormClosing(object sender, FormClosingEventArgs e)
         {
             ReleaseAllKeys(); //释放所有热键
-            WindowApiWrapper.UnregisterHotKey(Handle, 101); //注册F1热键,根据id值101来判断需要执行哪个函数
+            WindowApiWrapper.UnregisterHotKey(Handle, 101); //注册F10热键,根据id值101来判断需要执行哪个函数
             WindowApiWrapper.UnregisterHotKey(Handle, 102);
             WindowApiWrapper.UnregisterHotKey(Handle, 103);
             WindowApiWrapper.UnregisterHotKey(Handle, 104);
@@ -91,7 +91,14 @@ namespace BTD6AutoCommunity.Views.Main
             WindowApiWrapper.UnregisterHotKey(Handle, 106);
             WindowApiWrapper.UnregisterHotKey(Handle, 107);
             WindowApiWrapper.UnregisterHotKey(Handle, 108);
-
+            WindowApiWrapper.UnregisterHotKey(Handle, 111); //注册F9热键,根据id值111来判断需要执行哪个函数
+            WindowApiWrapper.UnregisterHotKey(Handle, 112);
+            WindowApiWrapper.UnregisterHotKey(Handle, 113);
+            WindowApiWrapper.UnregisterHotKey(Handle, 114);
+            WindowApiWrapper.UnregisterHotKey(Handle, 115);
+            WindowApiWrapper.UnregisterHotKey(Handle, 116);
+            WindowApiWrapper.UnregisterHotKey(Handle, 117);
+            WindowApiWrapper.UnregisterHotKey(Handle, 118);
         }
 
         private void ReleaseAllKeys()
@@ -105,15 +112,23 @@ namespace BTD6AutoCommunity.Views.Main
         // 将 Load 事件处理器改为异步，以便在 UI 线程安全地 await 更新检查
         private async void BTD6AutoCommunity_Load(object sender, EventArgs e)
         {
-            WindowApiWrapper.RegisterHotKey(Handle, 101, 0, Keys.F1); //注册F1热键,根据id值101来判断需要执行哪个函数
-            WindowApiWrapper.RegisterHotKey(Handle, 102, 1, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 103, 2, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 104, 3, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 105, 4, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 106, 5, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 107, 6, Keys.F1);
-            WindowApiWrapper.RegisterHotKey(Handle, 108, 7, Keys.F1);
+            WindowApiWrapper.RegisterHotKey(Handle, 101, 0, Keys.F10); //注册F10热键,根据id值101来判断需要执行哪个函数
+            WindowApiWrapper.RegisterHotKey(Handle, 102, 1, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 103, 2, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 104, 3, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 105, 4, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 106, 5, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 107, 6, Keys.F10);
+            WindowApiWrapper.RegisterHotKey(Handle, 108, 7, Keys.F10);
 
+            WindowApiWrapper.RegisterHotKey(Handle, 111, 0, Keys.F9); //注册F9热键,根据id值111来判断需要执行哪个函数
+            WindowApiWrapper.RegisterHotKey(Handle, 112, 1, Keys.F9);
+            WindowApiWrapper.RegisterHotKey(Handle, 113, 2, Keys.F9);
+            WindowApiWrapper.RegisterHotKey(Handle, 114, 3, Keys.F9);
+            WindowApiWrapper.RegisterHotKey(Handle, 115, 4, Keys.F9);
+            WindowApiWrapper.RegisterHotKey(Handle, 116, 5, Keys.F9);   
+            WindowApiWrapper.RegisterHotKey(Handle, 117, 6, Keys.F9);
+            WindowApiWrapper.RegisterHotKey(Handle, 118, 7, Keys.F9);
             await updateService.CheckUpdateAsync();
         }
 
@@ -139,12 +154,20 @@ namespace BTD6AutoCommunity.Views.Main
                         case 108:
                             StartProgramBT.PerformClick();
                             break;
+                        case 111:
+                        case 112:
+                        case 113:
+                        case 114:
+                        case 115:
+                        case 116:
+                        case 117:
+                           PauseBT.PerformClick();
+                            break;
                     }
                     break;
             }
             base.WndProc(ref m);
         }
-
 
     }
 }

--- a/BTD6AutoCommunity/Views/Main/StartPage.cs
+++ b/BTD6AutoCommunity/Views/Main/StartPage.cs
@@ -34,6 +34,7 @@ namespace BTD6AutoCommunity.Views.Main
             BindScriptComboBox();
             BindPreviewListBox();
             BindStartProgramButton();
+            BindPauseButton();
             BindImportScriptButton();
             BindOutputScriptButton();
             BindEditScriptButton();
@@ -278,11 +279,18 @@ namespace BTD6AutoCommunity.Views.Main
                                 color = Color.Gray;
                                 break;
                         }
+
+                        // 当行数超过1000时，移除顶部的行
                         if (logsRTB.Lines.Length >= 1000)
                         {
-                            logsRTB.Text = string.Join("\n",
-                                logsRTB.Lines.Skip(logsRTB.Lines.Length - 1000));
+                            logsRTB.SelectionStart = 0;
+                            logsRTB.SelectionLength = logsRTB.GetFirstCharIndexFromLine(1);
+                            logsRTB.SelectedText = "";
                         }
+
+                        // 将光标移到末尾并以指定颜色追加新日志
+                        logsRTB.SelectionStart = logsRTB.TextLength;
+                        logsRTB.SelectionLength = 0;
                         logsRTB.SelectionColor = color;
                         logsRTB.AppendText(startViewModel.CurrentLog.Message + "\n");
                         logsRTB.ScrollToCaret();
@@ -295,6 +303,13 @@ namespace BTD6AutoCommunity.Views.Main
         {
             StartProgramBT.DataBindings.Add("Text", startViewModel, "StartButtonText");
             StartProgramBT.Click += (s, e) => startViewModel.StartOrStopCommand.Execute(null);
+        }
+
+        private void BindPauseButton()
+        {
+            PauseBT.DataBindings.Add("Enabled", startViewModel, "PauseButtonEnabled");
+            PauseBT.DataBindings.Add("Text", startViewModel, "PauseButtonText");
+            PauseBT.Click += (s, e) => startViewModel.PauseOrResumeCommand.Execute(null);
         }
 
         private void BindImportScriptButton()


### PR DESCRIPTION
本次提交实现了脚本运行时的暂停与恢复（Pause/Resume）功能，扩展了IStrategyExecutor接口及BaseStrategy的相关逻辑。主界面新增了“暂停”按钮，支持F9快捷键控制暂停/继续，启动/终止快捷键由F1改为F10。同步优化了UI布局、控件字体与尺寸，移除冗余标签，并提升了日志显示性能。整体提升了用户体验和操作便捷性。