### PR TITLE
重构脚本导入逻辑，使用ImportScriptsService

### DIFF
--- a/BTD6AutoCommunity/Views/Main/MyScriptsPage.cs
+++ b/BTD6AutoCommunity/Views/Main/MyScriptsPage.cs
@@ -11,6 +11,7 @@ using BTD6AutoCommunity.Core;
 using BTD6AutoCommunity.ScriptEngine;
 using BTD6AutoCommunity.GameObjects;
 using BTD6AutoCommunity.ScriptEngine.ScriptSystem;
+using BTD6AutoCommunity.Services;
 
 namespace BTD6AutoCommunity.Views.Main
 {
@@ -201,32 +202,15 @@ namespace BTD6AutoCommunity.Views.Main
 
         private void ImportBT_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            ImportScriptsService importScriptsService = new ImportScriptsService();
+            var scriptModel = importScriptsService.ImportScripts();
+            if (scriptModel != null)
             {
-                if (openFileDialog.ShowDialog() == DialogResult.OK)
-                {
-                    string sourceFilePath = openFileDialog.FileName;
-                    string fileName = Path.GetFileName(sourceFilePath);
-                    string destinationFilePath = ScriptFileManager.GetScriptFullPath(ScriptFileManager.LoadScript(sourceFilePath));
-                    if (Path.GetExtension(fileName) == ".btd6")
-                    {
-                        try
-                        {
-                            File.Copy(sourceFilePath, destinationFilePath, true);
-                            SelectPath(Path.GetDirectoryName(destinationFilePath));
-                        }
-                        catch (IOException ex)
-                        {
-                            MessageBox.Show("脚本格式错误！" + ex.Message);
-                        }
-                    }
-                    else
-                    {
-                        MessageBox.Show("脚本格式错误！");
-                    }
-                }
+                string destinationFilePath = ScriptFileManager.GetScriptFullPath(scriptModel);
+                SelectPath(Path.GetDirectoryName(destinationFilePath));
             }
         }
+
 
         private void OutputBT_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
重构了脚本导入流程，移除了 ImportBT_Click 方法中直接操作文件的代码，改为通过 ImportScriptsService 统一处理导入逻辑，提高了代码的可维护性和复用性。同时在导入成功后自动选中脚本目录，并添加了相关命名空间引用。